### PR TITLE
fix: オンボーディング完了時のステップを3に修正

### DIFF
--- a/lib/core/presentation/widgets/onboarding/view_models/onboarding_view_model.dart
+++ b/lib/core/presentation/widgets/onboarding/view_models/onboarding_view_model.dart
@@ -107,9 +107,9 @@ class OnboardingViewModel extends StateNotifier<OnboardingState> {
     await completeStep(1);
   }
 
-  /// アカウント作成完了（ステップ2）
+  /// アカウント作成完了（ステップ3で完了扱い）
   Future<void> completeAccountCreation() async {
-    await completeStep(2);
+    await completeStep(3);
   }
 
   /// ゲストとして続行

--- a/lib/features/onboarding/presentation/view_models/onboarding_view_model.dart
+++ b/lib/features/onboarding/presentation/view_models/onboarding_view_model.dart
@@ -107,9 +107,9 @@ class OnboardingViewModel extends StateNotifier<OnboardingState> {
     await completeStep(1);
   }
 
-  /// アカウント作成完了（ステップ2）
+  /// アカウント作成完了（ステップ3で完了扱い）
   Future<void> completeAccountCreation() async {
-    await completeStep(2);
+    await completeStep(3);
   }
 
   /// ゲストとして続行


### PR DESCRIPTION
## 問題
- ゲストユーザーまたはアカウント登録後、アプリを再起動すると毎回「アカウント作成促進画面」(ステップ2)が表示されてしまう

## 原因
- `completeAccountCreation()`メソッドがステップ2に設定していた
- `startup_logic_service.dart`では`step >= 3`でオンボーディング完了と判定
- ステップ2の場合は`/onboarding/account-promotion`に遷移していた

## 修正内容
- `completeAccountCreation()`を`completeStep(3)`に変更
- ゲスト続行時も同様にステップ3でオンボーディング完了扱い

## 影響範囲
- `lib/features/onboarding/presentation/view_models/onboarding_view_model.dart`
- `lib/core/presentation/widgets/onboarding/view_models/onboarding_view_model.dart`

## テスト
- [x] iOS Debug ビルド成功
- [x] Android Debug ビルド成功
- [ ] ゲストユーザーで再起動してホーム画面が表示されることを確認（要手動テスト）
- [ ] アカウント登録後に再起動してホーム画面が表示されることを確認（要手動テスト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)