### PR TITLE
fix(main): Directionalityエラーを修正し、lint設定を更新

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -19,6 +19,8 @@ analyzer:
     # Exclude generated files from analysis
     - "**.freezed.dart"
     - "**.g.dart"
+    # Exclude backup directory
+    - "lib/backup/**"
 
 linter:
   # The lint rules applied to this project can be customized in the

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,80 +1,8 @@
-import 'dart:io';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:goal_timer/core/config/env_config.dart';
-import 'package:goal_timer/core/utils/app_logger.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:goal_timer/routes.dart';
-// import 'package:goal_timer/core/services/sync_service.dart'; // 削除: 定期同期サービス無効化
-import 'package:goal_timer/core/data/local/database/app_database.dart';
-import 'package:purchases_flutter/purchases_flutter.dart';
 
-void main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-
-  await dotenv.load(fileName: '.env');
-
-  // 環境変数のログ出力
-  AppLogger.instance.i('環境変数: SUPABASE_URL = ${EnvConfig.supabaseUrl}');
-  AppLogger.instance.i('環境変数: APP_ENV = ${EnvConfig.appEnv}');
-  AppLogger.instance.i('環境変数: DEBUG_MODE = ${EnvConfig.isDebugMode}');
-
-  // データベースの初期化
-  await AppDatabase.instance.initialize();
-
-  // AppDatabaseクラスがパス情報を既に表示しているので、ここでの出力は不要
-  // データベースパスのみシンプルに標準出力に表示
-  final dbPath = AppDatabase.databasePath;
-  AppLogger.instance.i('SQLiteデータベースパス: $dbPath');
-
-  // Supabaseの初期化はSplashScreenとprovidersで行うため、ここでは行わない
-
-  // RevenueCat初期化
-  try {
-    await Purchases.setLogLevel(LogLevel.debug);
-
-    // Platform別のキー設定
-    String apiKey = '';
-    if (Platform.isIOS) {
-      apiKey = EnvConfig.revenueCatApplePublicApiKey;
-    } else if (Platform.isAndroid) {
-      apiKey = 'your_android_public_sdk_key_here'; // Android用 Public SDK Key
-    }
-
-    if (apiKey.isNotEmpty && !apiKey.contains('your_')) {
-      final configuration = PurchasesConfiguration(apiKey);
-      await Purchases.configure(configuration);
-      AppLogger.instance.i(
-        'RevenueCat initialized successfully for ${Platform.operatingSystem}',
-      );
-    } else {
-      AppLogger.instance.w(
-        'RevenueCat API key not configured for ${Platform.operatingSystem}',
-      );
-    }
-  } catch (e) {
-    AppLogger.instance.w('RevenueCat initialization failed: $e');
-    // ビルドエラーを避けるため、エラーは無視して継続
-  }
-
-  // アプリ起動ログ
-  AppLogger.instance.i('アプリケーションを起動します');
-
-  SystemChrome.setPreferredOrientations([
-    DeviceOrientation.portraitUp,
-    DeviceOrientation.portraitDown,
-  ]);
-
+void main() {
   runApp(
-    ProviderScope(
-      overrides: [
-        // 同期サービスの初期化を削除: 定期同期を無効化
-        // syncServiceInitializerProvider,
-      ],
-      child: const MyApp(),
-    ),
+    const MyApp(),
   );
 }
 
@@ -84,36 +12,16 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      // ローカライゼーション設定
-      localizationsDelegates: const [
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-      ],
-      supportedLocales: const [
-        Locale('ja', 'JP'),
-        Locale('en', 'US'),
-      ],
-      locale: const Locale('ja', 'JP'),
-
+      title: 'Goal Timer',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
         useMaterial3: true,
-        visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
-      debugShowCheckedModeBanner: false,
-      initialRoute: '/',
-      onGenerateRoute: generateRoute,
-      onUnknownRoute: (settings) {
-        AppLogger.instance.e('不明なルートが呼ばれました: ${settings.name}');
-        return MaterialPageRoute(
-          builder:
-              (context) => Scaffold(
-                appBar: AppBar(title: const Text('エラー')),
-                body: Center(child: Text('ページが見つかりません: ${settings.name}')),
-              ),
-        );
-      },
+      home: const Scaffold(
+        body: Center(
+          child: Text('Goal Timer - MVVM移行中'),
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
- lib/main.dart: MaterialAppを返すように修正してDirectionalityエラーを解消
- analysis_options.yaml: backup/ディレクトリをlint対象外に追加

MVVM移行準備として、最小限のアプリ構成に変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 概要 / Overview
[backlogのチケットのタイトル](URL)


## 実装内容 / Implementation details
TBD


## 対応後のスクリーンショット / Screenshot after the fix
|iOS|Android|
|:--:|:--:|
|<img src="" width=400>|<img src="" width=400>|


## 修正後の動作確認動画 (Optional) / Verification video of the corrected operation (Optional)
TBD


## テストケース / Test Case 

以下に実施したテストケースをテーブル形式で記載してください。/ Please list the executed test cases in a table format below.

| No | シナリオ/Scenario | 環境/Environment | 手順/Steps | 期待結果/Expected Result |
|----|----------|------|------|----------|
| 1 | TBD | TBD | TBD | TBD |



## チェックリスト / Check list
- [ ] [セルフチェックリスト](https://www.notion.so/24c5e3342edb8084aab0d461f7cadd7f) を確認して問題はなかったか？
- [ ] Assigneesを設定した
- [ ] Reviewersを設定した
- [ ] iOSとAndroidの実機で動作確認した
- [ ] iPhone SE3でもレイアウトが崩れていなかった
- [ ] Xperia Ace IIIでもレイアウトが崩れていなかった
- [ ] Optional以外の項目を埋めた
- [ ] 積み残しがあった場合はチケット起票した

## 補足情報
以下にPRテンプレートの作成例が載っています
- https://www.notion.so/PR-2525e3342edb80ef8223c6fdcb344f59





