### PR TITLE
feat: 目標編集機能を実装

### DIFF
--- a/lib/features/goal_detail_setting/presentation/screens/goal_detail_setting_screen.dart
+++ b/lib/features/goal_detail_setting/presentation/screens/goal_detail_setting_screen.dart
@@ -1,14 +1,190 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:goal_timer/features/goal_timer/domain/entities/goal.dart';
+import 'package:goal_timer/features/goal_timer/presentation/viewmodels/goal_view_model.dart';
+import 'package:intl/intl.dart';
 
-class GoalDetailSettingScreen extends StatelessWidget {
-  const GoalDetailSettingScreen({super.key});
+class GoalDetailSettingScreen extends ConsumerStatefulWidget {
+  final Goal? goal;
+
+  const GoalDetailSettingScreen({super.key, this.goal});
+
+  @override
+  ConsumerState<GoalDetailSettingScreen> createState() =>
+      _GoalDetailSettingScreenState();
+}
+
+class _GoalDetailSettingScreenState
+    extends ConsumerState<GoalDetailSettingScreen> {
+  final _formKey = GlobalKey<FormState>();
+  late TextEditingController _titleController;
+  late TextEditingController _descriptionController;
+  late DateTime _selectedDate;
+  bool _isLoading = false;
+
+  bool get isEditMode => widget.goal != null;
+
+  @override
+  void initState() {
+    super.initState();
+    _titleController = TextEditingController(text: widget.goal?.title ?? '');
+    _descriptionController =
+        TextEditingController(text: widget.goal?.description ?? '');
+    _selectedDate =
+        widget.goal?.deadline ?? DateTime.now().add(const Duration(days: 7));
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _selectDate(BuildContext context) async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _selectedDate,
+      firstDate: DateTime.now(),
+      lastDate: DateTime.now().add(const Duration(days: 365 * 2)),
+    );
+
+    if (picked != null && picked != _selectedDate) {
+      setState(() {
+        _selectedDate = picked;
+      });
+    }
+  }
+
+  Future<void> _saveGoal() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      final repository = ref.read(goalRepositoryProvider);
+
+      if (isEditMode) {
+        final updatedGoal = widget.goal!.copyWith(
+          title: _titleController.text,
+          description: _descriptionController.text,
+          deadline: _selectedDate,
+        );
+
+        await repository.updateGoal(updatedGoal);
+
+        ref.invalidate(goalListProvider);
+
+        if (mounted) {
+          Navigator.of(context).pop();
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('ゴールが更新されました')),
+          );
+        }
+      } else {
+        final newGoal = Goal(
+          id: DateTime.now().millisecondsSinceEpoch.toString(),
+          title: _titleController.text,
+          description: _descriptionController.text,
+          deadline: _selectedDate,
+        );
+
+        await repository.addGoal(newGoal);
+
+        ref.invalidate(goalListProvider);
+
+        if (mounted) {
+          Navigator.of(context).pop();
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('ゴールが追加されました')),
+          );
+        }
+      }
+    } catch (error) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('エラーが発生しました: $error')),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-        child: Text('GoalDetailSettingScreen'),
-      )
+    final dateFormatter = DateFormat('yyyy年MM月dd日');
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(isEditMode ? 'ゴールを編集' : '新しいゴール'),
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: ListView(
+            children: [
+              TextFormField(
+                controller: _titleController,
+                decoration: const InputDecoration(
+                  labelText: 'タイトル',
+                  border: OutlineInputBorder(),
+                ),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'タイトルを入力してください';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _descriptionController,
+                decoration: const InputDecoration(
+                  labelText: '説明',
+                  border: OutlineInputBorder(),
+                ),
+                maxLines: 4,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return '説明を入力してください';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              ListTile(
+                title: const Text('期限日'),
+                subtitle: Text(dateFormatter.format(_selectedDate)),
+                trailing: const Icon(Icons.calendar_today),
+                onTap: () => _selectDate(context),
+              ),
+              const SizedBox(height: 32),
+              ElevatedButton(
+                onPressed: _isLoading ? null : _saveGoal,
+                style: ElevatedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                ),
+                child: _isLoading
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : Text(isEditMode ? 'ゴールを更新' : 'ゴールを保存'),
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:goal_timer/features/home/presentation/widgets/goal_list_cell_widget.dart';
+import 'package:goal_timer/features/goal_timer/presentation/viewmodels/goal_view_model.dart';
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends ConsumerWidget {
   const HomeScreen({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Material(
       color: Colors.white,
       child: SafeArea(
@@ -96,18 +98,35 @@ class DeadlineFilter extends StatelessWidget {
 
 // MARK: - MainContents
 
-class MainContents extends StatelessWidget {
+class MainContents extends ConsumerWidget {
   const MainContents({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final goalsAsync = ref.watch(goalListProvider);
+
     return Expanded(
-      child: ListView.builder( 
-        shrinkWrap: true,
-        itemCount: 20,
-        itemBuilder: (context, index) {
-          return const GoalListCellWidget();
+      child: goalsAsync.when(
+        data: (goals) {
+          if (goals.isEmpty) {
+            return const Center(
+              child: Text('ゴールがありません'),
+            );
+          }
+          return ListView.builder(
+            shrinkWrap: true,
+            itemCount: goals.length,
+            itemBuilder: (context, index) {
+              return GoalListCellWidget(goal: goals[index]);
+            },
+          );
         },
+        loading: () => const Center(
+          child: CircularProgressIndicator(),
+        ),
+        error: (error, stack) => Center(
+          child: Text('エラーが発生しました: $error'),
+        ),
       ),
     );
   }

--- a/lib/features/home/presentation/widgets/goal_list_cell_widget.dart
+++ b/lib/features/home/presentation/widgets/goal_list_cell_widget.dart
@@ -1,10 +1,24 @@
 import 'package:flutter/material.dart';
 
-import 'package:goal_timer/routes.dart';
 import 'package:goal_timer/core/utils/route_names.dart';
+import 'package:goal_timer/features/goal_timer/domain/entities/goal.dart';
 
 class GoalListCellWidget extends StatelessWidget {
-  const GoalListCellWidget({Key? key}) : super(key: key);
+  final Goal goal;
+
+  const GoalListCellWidget({Key? key, required this.goal}) : super(key: key);
+
+  String _getRemainingDays() {
+    final now = DateTime.now();
+    final difference = goal.deadline.difference(now).inDays;
+    if (difference < 0) {
+      return '期限切れ';
+    } else if (difference == 0) {
+      return '今日まで';
+    } else {
+      return '残り${difference}日';
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -17,6 +31,7 @@ class GoalListCellWidget extends StatelessWidget {
           Navigator.pushNamed(
             context,
             RouteNames.goalDetailSetting,
+            arguments: goal,
           );
         },
         borderRadius: BorderRadius.circular(12),
@@ -30,9 +45,9 @@ class GoalListCellWidget extends StatelessWidget {
                 children: [
                   Expanded(
                     child: Text(
-                      '今すぐやらないと後悔するぞ！',
+                      goal.title,
                       style: TextStyle(
-                        color: Colors.red[700],
+                        color: Colors.blue[700],
                         fontSize: 18,
                         fontWeight: FontWeight.bold,
                       ),
@@ -46,19 +61,19 @@ class GoalListCellWidget extends StatelessWidget {
                 ],
               ),
               const SizedBox(height: 8),
-              const Text(
-                'Flutterの基礎を完全に理解する',
-                style: TextStyle(fontSize: 16),
+              Text(
+                goal.description,
+                style: const TextStyle(fontSize: 16),
               ),
               const SizedBox(height: 12),
               Row(
                 children: [
-                  const Text('残り30日', style: TextStyle(color: Colors.grey)),
+                  Text(_getRemainingDays(), style: const TextStyle(color: Colors.grey)),
                   const Spacer(),
                   Text(
-                    '45%',
+                    goal.isCompleted ? '完了' : '進行中',
                     style: TextStyle(
-                      color: Colors.blue[700],
+                      color: goal.isCompleted ? Colors.green[700] : Colors.blue[700],
                       fontWeight: FontWeight.bold,
                     ),
                   ),
@@ -66,9 +81,11 @@ class GoalListCellWidget extends StatelessWidget {
               ),
               const SizedBox(height: 8),
               LinearProgressIndicator(
-                value: 0.45,
+                value: goal.isCompleted ? 1.0 : 0.0,
                 backgroundColor: Colors.grey[200],
-                valueColor: AlwaysStoppedAnimation<Color>(Colors.blue[700]!),
+                valueColor: AlwaysStoppedAnimation<Color>(
+                  goal.isCompleted ? Colors.green[700]! : Colors.blue[700]!,
+                ),
               ),
             ],
           ),

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -4,6 +4,7 @@ import 'package:goal_timer/core/utils/platform_route.dart';
 import 'package:goal_timer/features/home/presentation/screens/home_screen.dart';
 import 'package:goal_timer/features/goal_detail_setting/presentation/screens/goal_detail_setting_screen.dart';
 import 'package:goal_timer/core/utils/route_names.dart';
+import 'package:goal_timer/features/goal_timer/domain/entities/goal.dart';
 
 // TODO: 中規模・大規模になってきたら疎結合にすることを考える
 
@@ -14,8 +15,9 @@ Route<dynamic> generateRoute(
     case RouteNames.home:
       return platformPageRoute(builder: (context) => const HomeScreen());
     case RouteNames.goalDetailSetting:
+      final goal = settings.arguments as Goal?;
       return platformPageRoute(
-          builder: (context) => const GoalDetailSettingScreen());
+          builder: (context) => GoalDetailSettingScreen(goal: goal));
     default:
       return platformPageRoute(
         builder: (context) => const Scaffold(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,8 +5,8 @@ publish_to: 'none'
 version: 0.0.18+1
 
 environment:
-  sdk: '3.7.0'
-  flutter: '3.29.0'
+  sdk: '>=3.7.0 <4.0.0'
+  flutter: '>=3.29.0'
 
 dependencies:
   flutter:

--- a/test/features/goal_detail_setting/goal_update_test.dart
+++ b/test/features/goal_detail_setting/goal_update_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:goal_timer/features/goal_timer/domain/entities/goal.dart';
+import 'package:goal_timer/features/goal_timer/data/repositories/goal_repository_impl.dart';
+
+void main() {
+  group('GoalRepositoryImpl', () {
+    late GoalRepositoryImpl repository;
+
+    setUp(() {
+      repository = GoalRepositoryImpl();
+    });
+
+    test('updateGoal should update an existing goal', () async {
+      final goals = await repository.getAllGoals();
+      expect(goals.isNotEmpty, true);
+
+      final originalGoal = goals.first;
+      final updatedGoal = originalGoal.copyWith(
+        title: 'Updated Title',
+        description: 'Updated Description',
+      );
+
+      final result = await repository.updateGoal(updatedGoal);
+
+      expect(result.id, originalGoal.id);
+      expect(result.title, 'Updated Title');
+      expect(result.description, 'Updated Description');
+
+      final fetchedGoals = await repository.getAllGoals();
+      final fetchedGoal = fetchedGoals.firstWhere((g) => g.id == originalGoal.id);
+      expect(fetchedGoal.title, 'Updated Title');
+      expect(fetchedGoal.description, 'Updated Description');
+    });
+
+    test('updateGoal should throw exception for non-existent goal', () async {
+      final nonExistentGoal = Goal(
+        id: 'non-existent-id',
+        title: 'Non-existent Goal',
+        description: 'This goal does not exist',
+        deadline: DateTime.now().add(const Duration(days: 7)),
+      );
+
+      expect(
+        () => repository.updateGoal(nonExistentGoal),
+        throwsException,
+      );
+    });
+
+    test('updateGoal should preserve unchanged fields', () async {
+      final goals = await repository.getAllGoals();
+      expect(goals.isNotEmpty, true);
+
+      final originalGoal = goals.first;
+      final originalDeadline = originalGoal.deadline;
+      final originalIsCompleted = originalGoal.isCompleted;
+
+      final updatedGoal = originalGoal.copyWith(
+        title: 'Only Title Changed',
+      );
+
+      final result = await repository.updateGoal(updatedGoal);
+
+      expect(result.title, 'Only Title Changed');
+      expect(result.description, originalGoal.description);
+      expect(result.deadline, originalDeadline);
+      expect(result.isCompleted, originalIsCompleted);
+    });
+
+    test('Goal copyWith should create a new instance with updated values', () {
+      final original = Goal(
+        id: '1',
+        title: 'Original Title',
+        description: 'Original Description',
+        deadline: DateTime(2025, 12, 31),
+        isCompleted: false,
+      );
+
+      final updated = original.copyWith(
+        title: 'New Title',
+        description: 'New Description',
+      );
+
+      expect(updated.id, original.id);
+      expect(updated.title, 'New Title');
+      expect(updated.description, 'New Description');
+      expect(updated.deadline, original.deadline);
+      expect(updated.isCompleted, original.isCompleted);
+
+      expect(original.title, 'Original Title');
+      expect(original.description, 'Original Description');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

ホーム画面から目標を編集できる機能を実装しました。

主な変更点:
- `GoalDetailSettingScreen`を編集・新規作成の両方に対応するフォーム画面として実装
- `HomeScreen`をRiverpodの`ConsumerWidget`に変換し、`goalListProvider`から実際のゴールデータを表示
- `GoalListCellWidget`が実際のGoalデータを受け取り、タイトル・説明・残り日数を表示
- ルーティングでGoalパラメータを渡せるように更新
- SDK制約を`>=3.7.0 <4.0.0`に緩和

## Review & Testing Checklist for Human

- [ ] **実機/エミュレータでの動作確認**: ホーム画面からゴールをタップして編集画面に遷移し、タイトル・説明・期限日を変更して保存できることを確認
- [ ] **新規作成フローの確認**: 新規ゴール作成時に正しく動作することを確認（既存の新規作成導線がある場合）
- [ ] **状態更新の確認**: 編集後にホーム画面に戻った際、リストが正しく更新されていることを確認
- [ ] **バリデーションの確認**: 空のタイトル・説明でエラーメッセージが表示されることを確認

**推奨テスト手順:**
1. アプリを起動してホーム画面を表示
2. 既存のゴールをタップして編集画面に遷移
3. タイトルと説明を変更して「ゴールを更新」ボタンをタップ
4. ホーム画面に戻り、変更が反映されていることを確認

### Notes

- 開発環境にAndroid SDK/Xcodeがないため、ビルド検証はCIに依存しています
- テストは4件全てパス（`flutter test test/features/goal_detail_setting/goal_update_test.dart`）
- `flutter analyze`はエラーなし（既存コードのwarning/infoのみ）

Link to Devin run: https://app.devin.ai/sessions/fd2f1d46130d4a55996288023c25d7d9
Requested by: かきざきはやて (@KakizakiHayate)