### PR TITLE
feat: FABの位置を下部右側に変更し、設定タブでは非表示にする

### DIFF
--- a/lib/features/home/view/home_screen.dart
+++ b/lib/features/home/view/home_screen.dart
@@ -239,6 +239,11 @@ class _HomeTabContent extends StatelessWidget {
 
             // 目標リスト
             _buildGoalList(homeViewModel),
+
+            // FABがコンテンツに重ならないようにするための余白
+            const SliverToBoxAdapter(
+              child: SizedBox(height: 96.0),
+            ),
           ],
         );
       },


### PR DESCRIPTION
## 概要 / Overview
ホーム画面のFloatingActionButton（目標追加ボタン）の位置を下部中央から下部右側に変更し、設定タブでは非表示にする

## 実装内容 / Implementation details
1. `FloatingActionButtonLocation.centerFloat` を `FloatingActionButtonLocation.endFloat` に変更し、FABを画面下部右側に配置
2. `_tabController.index != 2` の条件を追加し、設定タブ（index: 2）ではFABを非表示に
3. `_HomeTabContent`の`CustomScrollView`末尾に96pxのパディングを追加し、FABがコンテンツと重ならないように対応

**変更ファイル:** `lib/features/home/view/home_screen.dart`

**FAB表示タブ:**
- ホームタブ (index: 0) → 表示
- タイマータブ (index: 1) → 表示
- 設定タブ (index: 2) → 非表示

## 対応後のスクリーンショット / Screenshot after the fix
|iOS|Android|
|:--:|:--:|
|TBD|TBD|

## 修正後の動作確認動画 (Optional) / Verification video of the corrected operation (Optional)
N/A

## テストケース / Test Case 

| No | シナリオ/Scenario | 環境/Environment | 手順/Steps | 期待結果/Expected Result |
|----|----------|------|------|----------|
| 1 | ホームタブでFAB表示確認 | iOS/Android | ホームタブを表示する | FABが画面下部右側に表示される |
| 2 | タイマータブでFAB表示確認 | iOS/Android | タイマータブを表示する | FABが画面下部右側に表示される |
| 3 | 設定タブでFAB非表示確認 | iOS/Android | 設定タブを表示する | FABが表示されない |
| 4 | FABタップ動作確認 | iOS/Android | ホームタブでFABをタップする | 目標追加モーダルが表示される |
| 5 | コンテンツ重なり確認 | iOS/Android | 目標リストをスクロールして最後のカードを表示する | 最後のカードがFABで隠れずに操作できる |

## チェックリスト / Check list
- [ ] [セルフチェックリスト](https://www.notion.so/24c5e3342edb8084aab0d461f7cadd7f) を確認して問題はなかったか？
- [ ] Assigneesを設定した
- [ ] Reviewersを設定した
- [ ] iOSとAndroidの実機で動作確認した
- [ ] iPhone SE3でもレイアウトが崩れていなかった
- [ ] Xperia Ace IIIでもレイアウトが崩れていなかった
- [ ] Optional以外の項目を埋めた
- [ ] 積み残しがあった場合はチケット起票した

## 補足情報
- **Link to Devin run:** https://app.devin.ai/sessions/c1c86dc0bd0b41599bba71bd3d18db2b
- **Requested by:** かきざきはやて (@KakizakiHayate)