### PR TITLE
fix: 学習完了ダイアログの完了ボタンを押した後にダイアログを閉じるように修正

### DIFF
--- a/lib/features/timer/view/timer_screen.dart
+++ b/lib/features/timer/view/timer_screen.dart
@@ -467,6 +467,8 @@ class _TimerScreenState extends State<TimerScreen> {
               ElevatedButton(
                 onPressed: () async {
                   await timerViewModel.onTappedTimerFinishButton();
+                  if (!context.mounted) return;
+                  Navigator.pop(context);
                 },
                 style: ElevatedButton.styleFrom(
                   backgroundColor: ColorConsts.success,


### PR DESCRIPTION
## 概要 / Overview
タイマー画面の学習完了ダイアログで「完了」ボタンを押してもダイアログが閉じない不具合を修正


## 実装内容 / Implementation details
学習完了ダイアログの「完了」ボタンの`onPressed`コールバックに、`Navigator.pop(context)`を追加してダイアログを閉じるように修正しました。

非同期処理（`onTappedTimerFinishButton()`）の完了後にcontextを使用するため、`context.mounted`チェックを追加してFlutterのベストプラクティスに従っています。

### 変更箇所
- `lib/features/timer/view/timer_screen.dart`: 完了ボタンのonPressedにダイアログを閉じる処理を追加


## 対応後のスクリーンショット / Screenshot after the fix
N/A（Devin環境では実機テスト不可のため、レビュアーによる確認をお願いします）


## テストケース / Test Case 

| No | シナリオ/Scenario | 環境/Environment | 手順/Steps | 期待結果/Expected Result |
|----|----------|------|------|----------|
| 1 | 学習完了ダイアログの完了ボタン | iOS/Android | 1. タイマー画面を開く<br>2. タイマーを開始して数秒待つ<br>3. 完了ボタン（チェックマーク）をタップ<br>4. 学習完了ダイアログで「完了」をタップ | ダイアログが閉じ、タイマーがリセットされる |
| 2 | キャンセルボタンの動作確認 | iOS/Android | 1. タイマー画面を開く<br>2. タイマーを開始して数秒待つ<br>3. 完了ボタンをタップ<br>4. 学習完了ダイアログで「キャンセル」をタップ | ダイアログが閉じ、タイマーは一時停止状態のまま |


## チェックリスト / Check list
- [ ] [セルフチェックリスト](https://www.notion.so/24c5e3342edb8084aab0d461f7cadd7f) を確認して問題はなかったか？
- [ ] Assigneesを設定した
- [ ] Reviewersを設定した
- [ ] iOSとAndroidの実機で動作確認した
- [ ] iPhone SE3でもレイアウトが崩れていなかった
- [ ] Xperia Ace IIIでもレイアウトが崩れていなかった
- [ ] Optional以外の項目を埋めた
- [ ] 積み残しがあった場合はチケット起票した

## 補足情報
**Devin Session**: https://app.devin.ai/sessions/df2213841e8340c1bca4fb0f75352334
**Requested by**: かきざきはやて (hayate.k.0704@gmail.com) / @KakizakiHayate

### レビュー時の確認ポイント
- 完了ボタンを押した後、ダイアログが正しく閉じることを確認してください
- 学習記録が正しくデータベースに保存されていることを確認してください