### PR TITLE
feat: アプリ名を「目標達成タイマー」に変更

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="goal_timer"
+        android:label="目標達成タイマー"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:enableOnBackInvokedCallback="true">

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Goal Timer</string>
+	<string>目標達成タイマー</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/lib/core/utils/app_consts.dart
+++ b/lib/core/utils/app_consts.dart
@@ -12,7 +12,7 @@ class AppConsts {
 
   // === アプリ情報 ===
   /// アプリ名
-  static const String appName = 'Goal Timer';
+  static const String appName = '目標達成タイマー';
 
   /// アプリバージョン
   static const String appVersion = '1.0.0';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,7 +35,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GetMaterialApp(
-      title: 'Goal Timer',
+      title: '目標達成タイマー',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: ColorConsts.primary),
         useMaterial3: true,


### PR DESCRIPTION
## Summary

- アプリ名を「Goal Timer」から「目標達成タイマー」に変更
- iOS/Android両プラットフォームおよびFlutter内部の設定を統一

## 変更内容

| ファイル | 変更箇所 | Before | After |
|----------|----------|--------|-------|
| `ios/Runner/Info.plist` | CFBundleDisplayName | Goal Timer | 目標達成タイマー |
| `android/app/src/main/AndroidManifest.xml` | android:label | goal_timer | 目標達成タイマー |
| `lib/main.dart` | GetMaterialApp title | Goal Timer | 目標達成タイマー |
| `lib/core/utils/app_consts.dart` | appName | Goal Timer | 目標達成タイマー |

## Test plan

- [x] `flutter analyze` でエラーなし
- [x] `flutter build ios --debug` が成功
- [x] `flutter build apk --debug` が成功
- [ ] iOS実機/シミュレーターでアプリ名が「目標達成タイマー」と表示される
- [ ] Android実機/エミュレーターでアプリ名が「目標達成タイマー」と表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)