### PR TITLE
fix: タイマーモードの表示文言を変更

### DIFF
--- a/lib/features/timer/view/timer_screen.dart
+++ b/lib/features/timer/view/timer_screen.dart
@@ -238,17 +238,17 @@ class _TimerScreenState extends State<TimerScreen> with WidgetsBindingObserver {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          // フォーカス（カウントダウン）
+          // カウントダウン
           _buildModeButton(
-            'フォーカス',
+            'カウントダウン',
             timerState.mode == TimerMode.countdown,
             () => _onModeTapped(timerViewModel, TimerMode.countdown),
             Icons.timer_outlined,
           ),
 
-          // フリー（カウントアップ）
+          // カウントアップ
           _buildModeButton(
-            'フリー',
+            'カウントアップ',
             timerState.mode == TimerMode.countup,
             () => _onModeTapped(timerViewModel, TimerMode.countup),
             Icons.all_inclusive,


### PR DESCRIPTION
## Summary
- タイマー画面のモード切り替えボタンの表示文言を変更
  - 「フォーカス」→「カウントダウン」
  - 「フリー」→「カウントアップ」

## Test plan
- [ ] タイマー画面でモード切り替えボタンが「カウントダウン」「カウントアップ」と表示されることを確認
- [ ] 各モードが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)