### PR TITLE
fix: ミニヒートマップの学習済みドットの色を統一

### DIFF
--- a/lib/core/widgets/mini_heatmap.dart
+++ b/lib/core/widgets/mini_heatmap.dart
@@ -10,9 +10,6 @@ class MiniHeatmap extends StatelessWidget {
 
   const MiniHeatmap({super.key, required this.studyDates});
 
-  /// 今日の学習済みドットの色（濃い緑）
-  static const Color todayStudiedColor = Color(0xFF059669);
-
   @override
   Widget build(BuildContext context) {
     final now = DateTime.now();
@@ -52,7 +49,7 @@ class MiniHeatmap extends StatelessWidget {
     if (isToday) {
       if (isStudied) {
         decoration = BoxDecoration(
-          color: todayStudiedColor,
+          color: ColorConsts.success,
           borderRadius: BorderRadius.circular(StreakConsts.dotBorderRadius),
         );
       } else {


### PR DESCRIPTION
## Summary
- ホーム画面のミニヒートマップで、今日と過去の日で異なる緑色が使用されていた問題を修正
- すべての学習済みドットを `ColorConsts.success`（`0xFF10B981` - 明るい緑）に統一

## 変更内容
- `lib/core/widgets/mini_heatmap.dart`
  - ハードコードされていた `todayStudiedColor`（`0xFF059669`）を削除
  - 今日の学習済みドットも `ColorConsts.success` を使用するように変更

## Test plan
- [ ] ホーム画面のミニヒートマップで、すべての学習済みドットが同じ緑色で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)