### PR TITLE
feat: 目標時間計算の補完機能とUI改善

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -84,7 +84,8 @@
       "Bash(tree:*)",
       "Bash(gh api:*)",
       "WebFetch(domain:zenn.dev)",
-      "Bash(dart run:*)"
+      "Bash(dart run:*)",
+      "Bash(git stash:*)"
     ],
     "deny": []
   },

--- a/lib/core/widgets/goal_card.dart
+++ b/lib/core/widgets/goal_card.dart
@@ -3,6 +3,7 @@ import '../utils/color_consts.dart';
 import '../utils/text_consts.dart';
 import '../utils/spacing_consts.dart';
 import '../utils/animation_consts.dart';
+import '../utils/time_utils.dart';
 import 'pressable_card.dart';
 
 /// 改善された目標カードウィジェット
@@ -13,6 +14,7 @@ class GoalCard extends StatelessWidget {
   final double progress; // 0.0 - 1.0
   final int streakDays;
   final String? avoidMessage;
+  final DateTime? deadline; // 期限日
   final VoidCallback? onTap;
   final VoidCallback? onTimerTap;
   final VoidCallback? onEditTap;
@@ -28,6 +30,7 @@ class GoalCard extends StatelessWidget {
     required this.progress,
     required this.streakDays,
     this.avoidMessage,
+    this.deadline,
     this.onTap,
     this.onTimerTap,
     this.onEditTap,
@@ -53,6 +56,12 @@ class GoalCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          // 回避メッセージを最上部に表示（最も目立たせる）
+          if (avoidMessage != null) ...[
+            _buildAvoidanceMessage(),
+            const SizedBox(height: SpacingConsts.m),
+          ],
+
           // ヘッダー行
           _buildHeader(),
 
@@ -61,9 +70,10 @@ class GoalCard extends StatelessWidget {
           // プログレス表示
           _buildProgress(),
 
-          if (avoidMessage != null) ...[
-            const SizedBox(height: SpacingConsts.m),
-            _buildAvoidanceMessage(),
+          // 期限表示
+          if (deadline != null) ...[
+            const SizedBox(height: SpacingConsts.s),
+            _buildDeadlineInfo(),
           ],
 
           const SizedBox(height: SpacingConsts.m),
@@ -85,7 +95,7 @@ class GoalCard extends StatelessWidget {
             children: [
               Text(
                 title,
-                style: TextConsts.h3.copyWith(
+                style: TextConsts.bodyLarge.copyWith(
                   color: ColorConsts.textPrimary,
                   fontWeight: FontWeight.bold,
                 ),
@@ -198,16 +208,20 @@ class GoalCard extends StatelessWidget {
         border: Border.all(color: ColorConsts.error.withOpacity(0.2), width: 1),
       ),
       child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Icon(Icons.warning_amber_rounded, color: ColorConsts.error, size: 18),
+          const Icon(
+            Icons.warning_amber_rounded,
+            color: ColorConsts.error,
+            size: 24,
+          ),
           const SizedBox(width: SpacingConsts.s),
           Expanded(
             child: Text(
               localAvoidMessage,
-              style: TextConsts.caption.copyWith(
+              style: TextConsts.h4.copyWith(
                 color: ColorConsts.error,
-                fontWeight: FontWeight.w600,
-                fontStyle: FontStyle.italic,
+                fontWeight: FontWeight.bold,
               ),
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
@@ -215,6 +229,32 @@ class GoalCard extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+
+  Widget _buildDeadlineInfo() {
+    final localDeadline = deadline;
+    if (localDeadline == null) return const SizedBox.shrink();
+
+    final remainingDays = TimeUtils.calculateRemainingDays(localDeadline);
+    final month = localDeadline.month;
+    final day = localDeadline.day;
+
+    return Row(
+      children: [
+        const Icon(
+          Icons.calendar_today_outlined,
+          size: 14,
+          color: ColorConsts.textSecondary,
+        ),
+        const SizedBox(width: SpacingConsts.xs),
+        Text(
+          '$month月$day日まで（あと$remainingDays日）',
+          style: TextConsts.caption.copyWith(
+            color: ColorConsts.textSecondary,
+          ),
+        ),
+      ],
     );
   }
 

--- a/lib/features/home/view/home_screen.dart
+++ b/lib/features/home/view/home_screen.dart
@@ -360,6 +360,7 @@ class _HomeTabContent extends StatelessWidget {
           progress: progress,
           streakDays: 0,
           avoidMessage: goal.avoidMessage.isNotEmpty ? goal.avoidMessage : null,
+          deadline: goal.deadline,
           onTap: () {
             // 目標詳細画面（Coming Soon）
           },

--- a/lib/features/home/view/widgets/add_goal_modal.dart
+++ b/lib/features/home/view/widgets/add_goal_modal.dart
@@ -431,7 +431,27 @@ class _AddGoalModalState extends State<AddGoalModal> {
             ),
           ),
         ),
+        // 総目標時間の表示（期限が選択されている場合のみ）
+        if (selectedDeadline != null) ...[
+          const SizedBox(height: SpacingConsts.s),
+          _buildTotalTargetTimeText(selectedDeadline),
+        ],
       ],
+    );
+  }
+
+  Widget _buildTotalTargetTimeText(DateTime deadline) {
+    final remainingDays = TimeUtils.calculateRemainingDays(deadline);
+    final totalTargetMinutes = TimeUtils.calculateTotalTargetMinutes(
+      targetMinutes: _targetMinutes,
+      remainingDays: remainingDays,
+    );
+
+    return Text(
+      '残り$remainingDays日 → 総目標時間: ${TimeUtils.formatMinutesToHoursAndMinutes(totalTargetMinutes)}',
+      style: TextConsts.bodySmall.copyWith(
+        color: ColorConsts.textSecondary,
+      ),
     );
   }
 

--- a/lib/features/home/view_model/home_view_model.dart
+++ b/lib/features/home/view_model/home_view_model.dart
@@ -48,10 +48,9 @@ class HomeState {
   /// totalTargetMinutesを使用して進捗率を計算
   double getProgressForGoal(GoalsModel goal) {
     final studiedMinutes = getStudiedMinutesForGoal(goal);
-    // totalTargetMinutesがnullの場合はtargetMinutesを使用（後方互換性）
-    final targetMinutes = goal.totalTargetMinutes ?? goal.targetMinutes;
+    final totalTargetMinutes = goal.totalTargetMinutes ?? 0;
     return TimeUtils.calculateProgressRateFromMinutes(
-      targetMinutes,
+      totalTargetMinutes,
       studiedMinutes,
     );
   }
@@ -98,6 +97,9 @@ class HomeViewModel extends GetxController {
 
       // 期限切れの目標を更新
       await _goalsDatasource.updateExpiredGoals();
+
+      // 既存目標のtotalTargetMinutesを補完（Issue #111実装前に作成された目標対応）
+      await _goalsDatasource.populateMissingTotalTargetMinutes();
 
       // 目標、学習時間、ストリークデータを並列で取得（Dart 3 Recordsで型安全に）
       final now = DateTime.now();


### PR DESCRIPTION
## Summary
- 既存目標のtotalTargetMinutesをアプリ起動時に自動補完（Issue #111実装前の目標対応）
- 目標作成/編集モーダルに総目標時間を動的表示（期限選択時）
- 目標カードに期限表示を追加（「X月Y日まで（あとZ日）」形式）
- 回避メッセージを最上部に移動し、スタイルを強調（アイコン・テキスト拡大）

## Test plan
- [ ] 既存目標（totalTargetMinutesがnull）が正しく補完されることを確認
- [ ] 目標作成/編集時に総目標時間が正しく表示されることを確認
- [ ] ホーム画面の目標カードに期限が表示されることを確認
- [ ] 回避メッセージが目立つ位置（最上部）に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)