### PR TITLE
fix: ATTダイアログが表示されない問題を修正

### DIFF
--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -41,10 +41,12 @@ class NotificationService {
       '@mipmap/ic_launcher',
     );
 
+    // 初期化時に自動で許可を求めない（ATTダイアログとの競合を防ぐため）
+    // 許可は requestPermission() で明示的に求める
     const iosSettings = DarwinInitializationSettings(
-      requestAlertPermission: true,
-      requestBadgePermission: true,
-      requestSoundPermission: true,
+      requestAlertPermission: false,
+      requestBadgePermission: false,
+      requestSoundPermission: false,
     );
 
     const initSettings = InitializationSettings(

--- a/lib/features/home/view/home_screen.dart
+++ b/lib/features/home/view/home_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../../../core/models/goals/goals_model.dart';
 import '../../../core/services/att_service.dart';
+import '../../../core/services/notification_service.dart';
 import '../../../core/utils/color_consts.dart';
 import '../../../core/utils/text_consts.dart';
 import '../../../core/utils/spacing_consts.dart';
@@ -69,16 +70,23 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
 
     _fabAnimationController.forward();
 
-    // ATTダイアログを表示（iOS 14.5以降）
-    // 最初のフレームがレンダリングされた後に表示する
+    // ATTダイアログと通知許可ダイアログを順次表示（iOS）
+    // iOSは複数のネイティブダイアログを同時に表示できないため、
+    // ATT → 通知の順で表示する
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _requestTrackingAuthorization();
+      _requestPermissions();
     });
   }
 
-  /// ATT（App Tracking Transparency）の許可をリクエストする
-  Future<void> _requestTrackingAuthorization() async {
+  /// ATTと通知の許可を順次リクエストする
+  /// iOSでは複数のネイティブダイアログを同時に表示できないため、
+  /// ATT → 通知の順で表示する
+  Future<void> _requestPermissions() async {
+    // 1. ATTダイアログを表示（iOS 14.5以降）
     await AttService.requestTrackingAuthorization();
+
+    // 2. ATT完了後に通知許可を表示
+    await NotificationService().requestPermission();
   }
 
   @override


### PR DESCRIPTION
## Summary
- iOSでATTダイアログが表示されない問題を修正
- 通知許可ダイアログとの競合が原因だったため、ATT → 通知の順で順次表示するよう変更

## 変更内容
- `notification_service.dart`: 初期化時の自動許可要求を無効化（`requestAlertPermission: false`）
- `home_screen.dart`: ATT → 通知の順で許可を順次リクエストするよう変更

## 原因
iOSは複数のネイティブダイアログを同時に表示できないため、通知許可ダイアログ（アプリ起動時に自動表示）とATTダイアログが競合し、ATTダイアログが表示されなかった。

## Test plan
- [x] `flutter analyze` - エラーなし
- [x] `flutter build ios --debug` - 成功
- [x] `flutter build apk --debug` - 成功
- [x] 実機でATTダイアログが表示されることを確認
- [x] ATTダイアログ応答後に通知許可ダイアログが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)