### PR TITLE
fix(settings): Obx内でobservable変数にアクセスしてGetXエラーを修正

### DIFF
--- a/lib/features/settings/view/settings_screen.dart
+++ b/lib/features/settings/view/settings_screen.dart
@@ -59,6 +59,9 @@ class _SettingsScreenState extends State<SettingsScreen>
   @override
   Widget build(BuildContext context) {
     return Obx(() {
+      // 監視対象のobservable変数にアクセス（子メソッド内の変数も追跡される）
+      _settingsViewModel.displayName.value;
+
       return Scaffold(
         backgroundColor: ColorConsts.backgroundPrimary,
         appBar: AppBar(


### PR DESCRIPTION
## Summary
- PR #154のコンフリクト解決時にエラーハンドリングコードを削除した結果、Obx内でobservable変数にアクセスしなくなりGetXエラーが発生していた
- displayName.valueにアクセスすることで修正

## Test plan
- [x] flutter analyze: No issues found
- [x] flutter test: 275件すべてパス
- [ ] 設定画面を開いてエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)