### PR TITLE
chore(debug): マイグレーション処理のデバッグログを追加 #159

### DIFF
--- a/lib/core/data/repositories/goals_repository.dart
+++ b/lib/core/data/repositories/goals_repository.dart
@@ -101,11 +101,13 @@ class GoalsRepository {
   ///
   /// [goal] 保存する目標モデル
   Future<GoalsModel> upsertGoal(GoalsModel goal) async {
-    if (await _migrationService.isMigrated()) {
-      AppLogger.instance.i('Supabaseに目標を保存します: ${goal.id}');
+    final isMigrated = await _migrationService.isMigrated();
+    AppLogger.instance.d('[GoalsRepository] upsertGoal: isMigrated=$isMigrated');
+    if (isMigrated) {
+      AppLogger.instance.i('[GoalsRepository] Supabaseに目標を保存します: ${goal.id}');
       return _supabaseDs.upsertGoal(goal);
     } else {
-      AppLogger.instance.i('ローカルDBに目標を保存します: ${goal.id}');
+      AppLogger.instance.i('[GoalsRepository] ローカルDBに目標を保存します: ${goal.id}');
       await _localDs.saveGoal(goal);
       return goal;
     }

--- a/lib/features/welcome/view_model/welcome_view_model.dart
+++ b/lib/features/welcome/view_model/welcome_view_model.dart
@@ -66,7 +66,13 @@ class WelcomeViewModel extends GetxController {
       AppLogger.instance.i('匿名認証成功: $userId');
 
       // データ移行を実行
+      AppLogger.instance.d('[WelcomeVM] _migrateDataIfNeeded 開始');
       await _migrateDataIfNeeded(userId);
+      AppLogger.instance.d('[WelcomeVM] _migrateDataIfNeeded 完了');
+
+      // 移行フラグの確認（デバッグ用）
+      final isMigratedNow = await _migrationService.isMigrated();
+      AppLogger.instance.d('[WelcomeVM] 遷移前 isMigrated=$isMigratedNow');
 
       // ホーム画面へ遷移
       Get.offAll(() => const HomeScreen());


### PR DESCRIPTION
## Summary

- Issue #159 の調査のため、マイグレーション処理に詳細なデバッグログを追加
- 新規インストールユーザー（匿名含む）がSupabaseに保存されない問題の原因特定用

## 追加したログ

| ファイル | 追加内容 |
|---------|---------|
| `MigrationService.isMigrated()` | 返り値をログ出力 |
| `MigrationService._setMigrated()` | 書き込み前後のログと検証 |
| `MigrationService.migrate()` | 各ステップで詳細ログ |
| `GoalsRepository.upsertGoal()` | `isMigrated()` の結果をログ出力 |
| `WelcomeViewModel.startAsGuest()` | マイグレーション前後とホーム遷移前のログ |

## Test plan

- [ ] アプリを新規インストールして「ゲストとして開始」
- [ ] ログに `[Migration]` プレフィックスのメッセージが出力されることを確認
- [ ] 目標追加時に `[GoalsRepository] upsertGoal: isMigrated=true/false` が出力されることを確認
- [ ] 上記ログから問題の原因を特定

## 関連Issue

- Refs: #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)