### PR TITLE
fix(analytics): デバッグモードでAnalyticsイベント送信をスキップするように修正

### DIFF
--- a/lib/core/services/firebase_service.dart
+++ b/lib/core/services/firebase_service.dart
@@ -100,6 +100,13 @@ class FirebaseService {
     String name,
     Map<String, Object>? parameters,
   ) async {
+    // デバッグモードでは送信をスキップ
+    if (kDebugMode) {
+      AppLogger.instance
+          .d('FirebaseService: デバッグモードのためイベント「$name」の送信をスキップ');
+      return;
+    }
+
     try {
       await _analytics?.logEvent(name: name, parameters: parameters);
       AppLogger.instance.i('FirebaseService: イベント「$name」を送信しました');


### PR DESCRIPTION
## Summary
- デバッグモード（`flutter run`）ではFirebase Analyticsイベントを送信しないように修正
- `CrashlyticsService`と同様に`kDebugMode`チェックを追加
- 開発時のテストデータがGoogle Analyticsに混入することを防止

## 変更内容
- `lib/core/services/firebase_service.dart`の`_logEvent`メソッドにデバッグモードチェックを追加

## Test plan
- [x] Lintチェック通過（`flutter analyze`）
- [x] 全テスト通過（`flutter test` - 286件）
- [x] IPAビルド確認（`flutter build ios --release --no-codesign`）
- [x] テスト実行時にログで「デバッグモードのためイベント送信をスキップ」が出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)