### PR TITLE
feat(i18n): 国際化基盤の構築 #170

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,3 @@
+arb-dir: lib/l10n
+template-arb-file: app_en.arb
+output-localization-file: app_localizations.dart

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,66 @@
+{
+  "@@locale": "en",
+
+  "appName": "Goal Timer",
+  "@appName": {
+    "description": "The name of the application"
+  },
+
+  "commonBtnCancel": "Cancel",
+  "@commonBtnCancel": {
+    "description": "Common cancel button text"
+  },
+
+  "commonBtnOk": "OK",
+  "@commonBtnOk": {
+    "description": "Common OK button text"
+  },
+
+  "commonBtnSave": "Save",
+  "@commonBtnSave": {
+    "description": "Common save button text"
+  },
+
+  "commonBtnDelete": "Delete",
+  "@commonBtnDelete": {
+    "description": "Common delete button text"
+  },
+
+  "defaultGuestName": "Guest",
+  "@defaultGuestName": {
+    "description": "Default name for guest users"
+  },
+
+  "timeFormatHoursMinutes": "{hours}h {minutes}m",
+  "@timeFormatHoursMinutes": {
+    "description": "Time format with hours and minutes",
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+
+  "timeFormatMinutes": "{minutes}m",
+  "@timeFormatMinutes": {
+    "description": "Time format with minutes only",
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+
+  "daysSuffix": "{count, plural, one{1 day} other{{count} days}}",
+  "@daysSuffix": {
+    "description": "Days suffix with plural support",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
+}

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1,0 +1,21 @@
+{
+  "@@locale": "ja",
+
+  "appName": "Goal Timer",
+
+  "commonBtnCancel": "キャンセル",
+
+  "commonBtnOk": "OK",
+
+  "commonBtnSave": "保存",
+
+  "commonBtnDelete": "削除",
+
+  "defaultGuestName": "ゲスト",
+
+  "timeFormatHoursMinutes": "{hours}時間{minutes}分",
+
+  "timeFormatMinutes": "{minutes}分",
+
+  "daysSuffix": "{count}日"
+}

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1,0 +1,188 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart' as intl;
+
+import 'app_localizations_en.dart';
+import 'app_localizations_ja.dart';
+
+// ignore_for_file: type=lint
+
+/// Callers can lookup localized strings with an instance of AppLocalizations
+/// returned by `AppLocalizations.of(context)`.
+///
+/// Applications need to include `AppLocalizations.delegate()` in their app's
+/// `localizationDelegates` list, and the locales they support in the app's
+/// `supportedLocales` list. For example:
+///
+/// ```dart
+/// import 'l10n/app_localizations.dart';
+///
+/// return MaterialApp(
+///   localizationsDelegates: AppLocalizations.localizationsDelegates,
+///   supportedLocales: AppLocalizations.supportedLocales,
+///   home: MyApplicationHome(),
+/// );
+/// ```
+///
+/// ## Update pubspec.yaml
+///
+/// Please make sure to update your pubspec.yaml to include the following
+/// packages:
+///
+/// ```yaml
+/// dependencies:
+///   # Internationalization support.
+///   flutter_localizations:
+///     sdk: flutter
+///   intl: any # Use the pinned version from flutter_localizations
+///
+///   # Rest of dependencies
+/// ```
+///
+/// ## iOS Applications
+///
+/// iOS applications define key application metadata, including supported
+/// locales, in an Info.plist file that is built into the application bundle.
+/// To configure the locales supported by your app, you’ll need to edit this
+/// file.
+///
+/// First, open your project’s ios/Runner.xcworkspace Xcode workspace file.
+/// Then, in the Project Navigator, open the Info.plist file under the Runner
+/// project’s Runner folder.
+///
+/// Next, select the Information Property List item, select Add Item from the
+/// Editor menu, then select Localizations from the pop-up menu.
+///
+/// Select and expand the newly-created Localizations item then, for each
+/// locale your application supports, add a new item and select the locale
+/// you wish to add from the pop-up menu in the Value field. This list should
+/// be consistent with the languages listed in the AppLocalizations.supportedLocales
+/// property.
+abstract class AppLocalizations {
+  AppLocalizations(String locale)
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+
+  final String localeName;
+
+  static AppLocalizations? of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations);
+  }
+
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
+
+  /// A list of this localizations delegate along with the default localizations
+  /// delegates.
+  ///
+  /// Returns a list of localizations delegates containing this delegate along with
+  /// GlobalMaterialLocalizations.delegate, GlobalCupertinoLocalizations.delegate,
+  /// and GlobalWidgetsLocalizations.delegate.
+  ///
+  /// Additional delegates can be added by appending to this list in
+  /// MaterialApp. This list does not have to be used at all if a custom list
+  /// of delegates is preferred or required.
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
+
+  /// A list of this localizations delegate's supported locales.
+  static const List<Locale> supportedLocales = <Locale>[
+    Locale('en'),
+    Locale('ja'),
+  ];
+
+  /// The name of the application
+  ///
+  /// In en, this message translates to:
+  /// **'Goal Timer'**
+  String get appName;
+
+  /// Common cancel button text
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get commonBtnCancel;
+
+  /// Common OK button text
+  ///
+  /// In en, this message translates to:
+  /// **'OK'**
+  String get commonBtnOk;
+
+  /// Common save button text
+  ///
+  /// In en, this message translates to:
+  /// **'Save'**
+  String get commonBtnSave;
+
+  /// Common delete button text
+  ///
+  /// In en, this message translates to:
+  /// **'Delete'**
+  String get commonBtnDelete;
+
+  /// Default name for guest users
+  ///
+  /// In en, this message translates to:
+  /// **'Guest'**
+  String get defaultGuestName;
+
+  /// Time format with hours and minutes
+  ///
+  /// In en, this message translates to:
+  /// **'{hours}h {minutes}m'**
+  String timeFormatHoursMinutes(int hours, int minutes);
+
+  /// Time format with minutes only
+  ///
+  /// In en, this message translates to:
+  /// **'{minutes}m'**
+  String timeFormatMinutes(int minutes);
+
+  /// Days suffix with plural support
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, one{1 day} other{{count} days}}'**
+  String daysSuffix(int count);
+}
+
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  Future<AppLocalizations> load(Locale locale) {
+    return SynchronousFuture<AppLocalizations>(lookupAppLocalizations(locale));
+  }
+
+  @override
+  bool isSupported(Locale locale) =>
+      <String>['en', 'ja'].contains(locale.languageCode);
+
+  @override
+  bool shouldReload(_AppLocalizationsDelegate old) => false;
+}
+
+AppLocalizations lookupAppLocalizations(Locale locale) {
+  // Lookup logic when only language code is specified.
+  switch (locale.languageCode) {
+    case 'en':
+      return AppLocalizationsEn();
+    case 'ja':
+      return AppLocalizationsJa();
+  }
+
+  throw FlutterError(
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.',
+  );
+}

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1,0 +1,49 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for English (`en`).
+class AppLocalizationsEn extends AppLocalizations {
+  AppLocalizationsEn([String locale = 'en']) : super(locale);
+
+  @override
+  String get appName => 'Goal Timer';
+
+  @override
+  String get commonBtnCancel => 'Cancel';
+
+  @override
+  String get commonBtnOk => 'OK';
+
+  @override
+  String get commonBtnSave => 'Save';
+
+  @override
+  String get commonBtnDelete => 'Delete';
+
+  @override
+  String get defaultGuestName => 'Guest';
+
+  @override
+  String timeFormatHoursMinutes(int hours, int minutes) {
+    return '${hours}h ${minutes}m';
+  }
+
+  @override
+  String timeFormatMinutes(int minutes) {
+    return '${minutes}m';
+  }
+
+  @override
+  String daysSuffix(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count days',
+      one: '1 day',
+    );
+    return '$_temp0';
+  }
+}

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1,0 +1,43 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Japanese (`ja`).
+class AppLocalizationsJa extends AppLocalizations {
+  AppLocalizationsJa([String locale = 'ja']) : super(locale);
+
+  @override
+  String get appName => 'Goal Timer';
+
+  @override
+  String get commonBtnCancel => 'キャンセル';
+
+  @override
+  String get commonBtnOk => 'OK';
+
+  @override
+  String get commonBtnSave => '保存';
+
+  @override
+  String get commonBtnDelete => '削除';
+
+  @override
+  String get defaultGuestName => 'ゲスト';
+
+  @override
+  String timeFormatHoursMinutes(int hours, int minutes) {
+    return '$hours時間$minutes分';
+  }
+
+  @override
+  String timeFormatMinutes(int minutes) {
+    return '$minutes分';
+  }
+
+  @override
+  String daysSuffix(int count) {
+    return '$count日';
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:get/get.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -10,6 +11,7 @@ import 'core/utils/app_logger.dart';
 import 'core/utils/color_consts.dart';
 import 'features/settings/view_model/settings_view_model.dart';
 import 'features/splash/view/splash_screen.dart';
+import 'l10n/app_localizations.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -83,11 +85,26 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GetMaterialApp(
-      title: '目標達成タイマー',
+      title: 'Goal Timer',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: ColorConsts.primary),
         useMaterial3: true,
       ),
+      // 国際化設定
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: AppLocalizations.supportedLocales,
+      localeResolutionCallback: (locale, supportedLocales) {
+        // 日本語の場合は日本語、それ以外は英語にフォールバック
+        if (locale?.languageCode == 'ja') {
+          return const Locale('ja');
+        }
+        return const Locale('en');
+      },
       home: const SplashScreen(),
       debugShowCheckedModeBanner: false,
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,6 +65,7 @@ dev_dependencies:
     path: tanzam_lints
 
 flutter:
+  generate: true
   uses-material-design: true
   
   # 環境変数ファイルのアセット登録

--- a/test/core/l10n/app_localizations_test.dart
+++ b/test/core/l10n/app_localizations_test.dart
@@ -1,0 +1,291 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:goal_timer/l10n/app_localizations.dart';
+
+void main() {
+  group('AppLocalizations', () {
+    // L10N-001: flutter gen-l10nでコード生成が成功する
+    // （このテストはビルド時に確認されるため、ファイルの存在を確認）
+    test('L10N-001: AppLocalizations class exists', () {
+      expect(AppLocalizations, isNotNull);
+      expect(AppLocalizations.delegate, isNotNull);
+    });
+
+    // L10N-002: 日本語ロケール(ja)でAppLocalizationsが取得できる
+    testWidgets('L10N-002: Japanese locale returns AppLocalizations instance',
+        (WidgetTester tester) async {
+      late AppLocalizations? l10n;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('ja'),
+          home: Builder(
+            builder: (context) {
+              l10n = AppLocalizations.of(context);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(l10n, isNotNull);
+    });
+
+    // L10N-003: 英語ロケール(en)でAppLocalizationsが取得できる
+    testWidgets('L10N-003: English locale returns AppLocalizations instance',
+        (WidgetTester tester) async {
+      late AppLocalizations? l10n;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('en'),
+          home: Builder(
+            builder: (context) {
+              l10n = AppLocalizations.of(context);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(l10n, isNotNull);
+    });
+
+    // L10N-004: サポート外ロケール(zh)で英語にフォールバックする
+    testWidgets(
+        'L10N-004: Unsupported locale (zh) falls back to English',
+        (WidgetTester tester) async {
+      late AppLocalizations? l10n;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          localeResolutionCallback: (locale, supportedLocales) {
+            if (locale?.languageCode == 'ja') {
+              return const Locale('ja');
+            }
+            return const Locale('en');
+          },
+          locale: const Locale('zh'),
+          home: Builder(
+            builder: (context) {
+              l10n = AppLocalizations.of(context);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      // フォールバックにより英語のテキストが返る
+      expect(l10n, isNotNull);
+      expect(l10n!.defaultGuestName, 'Guest');
+    });
+
+    // L10N-005: 日本語ロケールで日本語テキストが返る
+    testWidgets('L10N-005: Japanese locale returns Japanese text',
+        (WidgetTester tester) async {
+      late AppLocalizations? l10n;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('ja'),
+          home: Builder(
+            builder: (context) {
+              l10n = AppLocalizations.of(context);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(l10n!.appName, 'Goal Timer');
+      expect(l10n!.defaultGuestName, 'ゲスト');
+      expect(l10n!.commonBtnCancel, 'キャンセル');
+      expect(l10n!.commonBtnSave, '保存');
+    });
+
+    // L10N-006: 英語ロケールで英語テキストが返る
+    testWidgets('L10N-006: English locale returns English text',
+        (WidgetTester tester) async {
+      late AppLocalizations? l10n;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('en'),
+          home: Builder(
+            builder: (context) {
+              l10n = AppLocalizations.of(context);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(l10n!.appName, 'Goal Timer');
+      expect(l10n!.defaultGuestName, 'Guest');
+      expect(l10n!.commonBtnCancel, 'Cancel');
+      expect(l10n!.commonBtnSave, 'Save');
+    });
+
+    // L10N-007: supportedLocalesにja, enが含まれる
+    test('L10N-007: supportedLocales contains ja and en', () {
+      final supportedLocales = AppLocalizations.supportedLocales;
+
+      expect(supportedLocales, contains(const Locale('en')));
+      expect(supportedLocales, contains(const Locale('ja')));
+    });
+
+    // L10N-008: localizationsDelegatesが正しく設定される
+    test('L10N-008: localizationsDelegates are correctly configured', () {
+      expect(AppLocalizations.delegate, isNotNull);
+      expect(GlobalMaterialLocalizations.delegate, isNotNull);
+      expect(GlobalWidgetsLocalizations.delegate, isNotNull);
+      expect(GlobalCupertinoLocalizations.delegate, isNotNull);
+    });
+  });
+
+  group('AppLocalizations - Time Format', () {
+    testWidgets('Japanese time format with hours and minutes',
+        (WidgetTester tester) async {
+      late AppLocalizations? l10n;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('ja'),
+          home: Builder(
+            builder: (context) {
+              l10n = AppLocalizations.of(context);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(l10n!.timeFormatHoursMinutes(1, 30), '1時間30分');
+      expect(l10n!.timeFormatMinutes(30), '30分');
+    });
+
+    testWidgets('English time format with hours and minutes',
+        (WidgetTester tester) async {
+      late AppLocalizations? l10n;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('en'),
+          home: Builder(
+            builder: (context) {
+              l10n = AppLocalizations.of(context);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(l10n!.timeFormatHoursMinutes(1, 30), '1h 30m');
+      expect(l10n!.timeFormatMinutes(30), '30m');
+    });
+  });
+
+  group('AppLocalizations - Plural', () {
+    testWidgets('Japanese days suffix (no plural)', (WidgetTester tester) async {
+      late AppLocalizations? l10n;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('ja'),
+          home: Builder(
+            builder: (context) {
+              l10n = AppLocalizations.of(context);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(l10n!.daysSuffix(1), '1日');
+      expect(l10n!.daysSuffix(5), '5日');
+    });
+
+    testWidgets('English days suffix (with plural)', (WidgetTester tester) async {
+      late AppLocalizations? l10n;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('en'),
+          home: Builder(
+            builder: (context) {
+              l10n = AppLocalizations.of(context);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(l10n!.daysSuffix(1), '1 day');
+      expect(l10n!.daysSuffix(5), '5 days');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Flutter公式の国際化（ARB + gen-l10n）基盤を構築
- 日本語・英語の自動切り替えを実装
- 基本的な共通キー（ボタン、時間フォーマット、複数形）を定義

## 変更内容
- `l10n.yaml`: l10n設定ファイルを作成
- `lib/l10n/app_en.arb`: 英語ARBファイルを作成
- `lib/l10n/app_ja.arb`: 日本語ARBファイルを作成
- `lib/main.dart`: GetMaterialAppに国際化設定を追加
- `pubspec.yaml`: `generate: true`を追加

## 確定仕様
| 項目 | 内容 |
|------|------|
| 言語判定 | システム言語自動検出（日本語→日本語、それ以外→英語） |
| 時間表示 | 日本語: 1時間30分 / 英語: 1h 30m |
| 複数形 | ICU MessageFormat（plural形式）を使用 |

## Test plan
- [x] `flutter gen-l10n`でコード生成成功
- [x] `flutter analyze` - No issues
- [x] `dart run custom_lint` - No issues
- [x] `flutter test` - 315 tests passed
- [x] `flutter build ios --release --no-codesign` - ビルド成功

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)