### PR TITLE
feat(i18n): 学習記録・目標モーダルの国際化対応 #173

### DIFF
--- a/lib/features/home/view/widgets/add_goal_modal.dart
+++ b/lib/features/home/view/widgets/add_goal_modal.dart
@@ -5,10 +5,10 @@ import 'package:intl/intl.dart';
 import '../../../../core/models/goals/goals_model.dart';
 import '../../../../core/utils/color_consts.dart';
 import '../../../../core/utils/spacing_consts.dart';
-import '../../../../core/utils/string_consts.dart';
 import '../../../../core/utils/text_consts.dart';
 import '../../../../core/utils/time_utils.dart';
 import '../../../../core/utils/ui_consts.dart';
+import '../../../../l10n/app_localizations.dart';
 import '../../view_model/home_view_model.dart';
 
 class AddGoalModal extends StatefulWidget {
@@ -91,10 +91,11 @@ class _AddGoalModalState extends State<AddGoalModal> {
     }
 
     final selectedDeadline = _selectedDeadline;
+    final l10n = AppLocalizations.of(context);
     if (selectedDeadline == null) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text(StringConsts.selectDeadlineMessage),
+        SnackBar(
+          content: Text(l10n?.selectDeadlineValidation ?? 'Please select a deadline'),
           backgroundColor: ColorConsts.error,
         ),
       );
@@ -104,6 +105,12 @@ class _AddGoalModalState extends State<AddGoalModal> {
     // async gapの前にcontext関連の参照をキャプチャ
     final scaffoldMessenger = ScaffoldMessenger.of(context);
     final navigator = Navigator.of(context);
+    final successMessage = _isEdit
+        ? (l10n?.goalUpdatedMessage ?? 'Goal updated')
+        : (l10n?.goalAddedMessage ?? 'Goal added');
+    final errorMessage = _isEdit
+        ? (l10n?.goalUpdateFailedMessage ?? 'Failed to update goal')
+        : (l10n?.goalAddFailedMessage ?? 'Failed to add goal');
 
     setState(() {
       _isLoading = true;
@@ -135,11 +142,7 @@ class _AddGoalModalState extends State<AddGoalModal> {
         navigator.pop();
         scaffoldMessenger.showSnackBar(
           SnackBar(
-            content: Text(
-              _isEdit
-                  ? StringConsts.goalUpdatedMessage
-                  : StringConsts.goalAddedMessage,
-            ),
+            content: Text(successMessage),
             backgroundColor: ColorConsts.success,
           ),
         );
@@ -148,11 +151,7 @@ class _AddGoalModalState extends State<AddGoalModal> {
       if (mounted) {
         scaffoldMessenger.showSnackBar(
           SnackBar(
-            content: Text(
-              _isEdit
-                  ? StringConsts.goalUpdateFailedMessage
-                  : StringConsts.goalAddFailedMessage,
-            ),
+            content: Text(errorMessage),
             backgroundColor: ColorConsts.error,
           ),
         );
@@ -221,6 +220,11 @@ class _AddGoalModalState extends State<AddGoalModal> {
   }
 
   Widget _buildHeader() {
+    final l10n = AppLocalizations.of(context);
+    final title = _isEdit
+        ? (l10n?.editGoalTitle ?? 'Edit Goal')
+        : (l10n?.addGoalTitle ?? 'Add Goal');
+
     return Container(
       padding: const EdgeInsets.all(SpacingConsts.l),
       decoration: const BoxDecoration(
@@ -241,7 +245,7 @@ class _AddGoalModalState extends State<AddGoalModal> {
         children: [
           Expanded(
             child: Text(
-              _isEdit ? StringConsts.editGoalTitle : StringConsts.addGoalTitle,
+              title,
               style: TextConsts.h3.copyWith(
                 color: ColorConsts.textPrimary,
                 fontWeight: FontWeight.bold,
@@ -259,11 +263,13 @@ class _AddGoalModalState extends State<AddGoalModal> {
   }
 
   Widget _buildTitleField() {
+    final l10n = AppLocalizations.of(context);
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          StringConsts.goalNameLabel,
+          l10n?.goalNameLabel ?? 'Goal Name *',
           style: TextConsts.body.copyWith(
             color: ColorConsts.textPrimary,
             fontWeight: FontWeight.w600,
@@ -273,7 +279,7 @@ class _AddGoalModalState extends State<AddGoalModal> {
         TextFormField(
           controller: _titleController,
           decoration: InputDecoration(
-            hintText: StringConsts.goalNamePlaceholder,
+            hintText: l10n?.goalNamePlaceholder ?? 'e.g. Get TOEIC 800',
             filled: true,
             fillColor: ColorConsts.cardBackground,
             border: OutlineInputBorder(
@@ -285,7 +291,7 @@ class _AddGoalModalState extends State<AddGoalModal> {
           maxLength: 50,
           validator: (value) {
             if (value == null || value.trim().isEmpty) {
-              return StringConsts.goalNameRequired;
+              return l10n?.goalNameRequired ?? 'Please enter a goal name';
             }
             return null;
           },
@@ -295,11 +301,13 @@ class _AddGoalModalState extends State<AddGoalModal> {
   }
 
   Widget _buildDescriptionField() {
+    final l10n = AppLocalizations.of(context);
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          StringConsts.descriptionLabel,
+          l10n?.descriptionLabel ?? 'Description',
           style: TextConsts.body.copyWith(
             color: ColorConsts.textPrimary,
             fontWeight: FontWeight.w600,
@@ -309,7 +317,7 @@ class _AddGoalModalState extends State<AddGoalModal> {
         TextFormField(
           controller: _descriptionController,
           decoration: InputDecoration(
-            hintText: StringConsts.descriptionPlaceholder,
+            hintText: l10n?.descriptionPlaceholder ?? 'e.g. I want to improve my English for working abroad',
             filled: true,
             fillColor: ColorConsts.cardBackground,
             border: OutlineInputBorder(
@@ -326,11 +334,13 @@ class _AddGoalModalState extends State<AddGoalModal> {
   }
 
   Widget _buildTargetMinutesField() {
+    final l10n = AppLocalizations.of(context);
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          StringConsts.targetMinutesLabel,
+          l10n?.targetMinutesLabel ?? 'Daily Study Time *',
           style: TextConsts.body.copyWith(
             color: ColorConsts.textPrimary,
             fontWeight: FontWeight.w600,
@@ -341,7 +351,7 @@ class _AddGoalModalState extends State<AddGoalModal> {
           onTap: () async {
             await showDialog(
               context: context,
-              builder: (BuildContext context) {
+              builder: (BuildContext dialogContext) {
                 return _TimePickerDialog(
                   initialMinutes: _targetMinutes,
                   onTimeSelected: (minutes) {
@@ -391,12 +401,13 @@ class _AddGoalModalState extends State<AddGoalModal> {
 
   Widget _buildDeadlineField() {
     final selectedDeadline = _selectedDeadline;
+    final l10n = AppLocalizations.of(context);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          StringConsts.deadlineLabel,
+          l10n?.deadlineLabel ?? 'Deadline *',
           style: TextConsts.body.copyWith(
             color: ColorConsts.textPrimary,
             fontWeight: FontWeight.w600,
@@ -423,7 +434,7 @@ class _AddGoalModalState extends State<AddGoalModal> {
                   child: Text(
                     selectedDeadline != null
                         ? DateFormat('yyyy年M月d日').format(selectedDeadline)
-                        : StringConsts.selectDeadlinePlaceholder,
+                        : (l10n?.selectDeadlinePlaceholder ?? 'Select a deadline'),
                     style: TextConsts.body.copyWith(
                       color:
                           selectedDeadline != null
@@ -456,9 +467,11 @@ class _AddGoalModalState extends State<AddGoalModal> {
       targetMinutes: _targetMinutes,
       remainingDays: remainingDays,
     );
+    final l10n = AppLocalizations.of(context);
+    final formattedTime = TimeUtils.formatMinutesToHoursAndMinutes(totalTargetMinutes);
 
     return Text(
-      '残り$remainingDays日 → 総目標時間: ${TimeUtils.formatMinutesToHoursAndMinutes(totalTargetMinutes)}',
+      l10n?.remainingDaysInfo(remainingDays, formattedTime) ?? '$remainingDays days left → Total target: $formattedTime',
       style: TextConsts.bodySmall.copyWith(
         color: ColorConsts.textSecondary,
       ),
@@ -466,11 +479,13 @@ class _AddGoalModalState extends State<AddGoalModal> {
   }
 
   Widget _buildAvoidMessageField() {
+    final l10n = AppLocalizations.of(context);
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          StringConsts.avoidMessageLabel,
+          l10n?.avoidMessageLabel ?? "What happens if you don't achieve it? *",
           style: TextConsts.body.copyWith(
             color: ColorConsts.textPrimary,
             fontWeight: FontWeight.w600,
@@ -478,14 +493,14 @@ class _AddGoalModalState extends State<AddGoalModal> {
         ),
         const SizedBox(height: SpacingConsts.xs),
         Text(
-          StringConsts.avoidMessageHint,
+          l10n?.avoidMessageHint ?? 'Clarifying negative outcomes helps maintain motivation',
           style: TextConsts.caption.copyWith(color: ColorConsts.textTertiary),
         ),
         const SizedBox(height: SpacingConsts.s),
         TextFormField(
           controller: _avoidMessageController,
           decoration: InputDecoration(
-            hintText: StringConsts.avoidMessagePlaceholder,
+            hintText: l10n?.avoidMessagePlaceholder ?? 'e.g. Miss career advancement opportunities',
             filled: true,
             fillColor: ColorConsts.cardBackground,
             border: OutlineInputBorder(
@@ -498,7 +513,7 @@ class _AddGoalModalState extends State<AddGoalModal> {
           maxLength: 200,
           validator: (value) {
             if (value == null || value.trim().isEmpty) {
-              return StringConsts.avoidMessageRequired;
+              return l10n?.avoidMessageRequired ?? "Please enter what happens if you don't achieve it";
             }
             return null;
           },
@@ -508,6 +523,11 @@ class _AddGoalModalState extends State<AddGoalModal> {
   }
 
   Widget _buildSaveButton() {
+    final l10n = AppLocalizations.of(context);
+    final buttonText = _isEdit
+        ? (l10n?.btnUpdate ?? 'Update')
+        : (l10n?.commonBtnSave ?? 'Save');
+
     return SizedBox(
       width: double.infinity,
       child: ElevatedButton(
@@ -532,7 +552,7 @@ class _AddGoalModalState extends State<AddGoalModal> {
                   ),
                 )
                 : Text(
-                  _isEdit ? StringConsts.updateButton : StringConsts.saveButton,
+                  buttonText,
                   style: TextConsts.h4.copyWith(
                     color: Colors.white,
                     fontWeight: FontWeight.bold,
@@ -583,6 +603,8 @@ class _TimePickerDialogState extends State<_TimePickerDialog> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
     return Dialog(
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       child: Container(
@@ -591,7 +613,7 @@ class _TimePickerDialogState extends State<_TimePickerDialog> {
           mainAxisSize: MainAxisSize.min,
           children: [
             Text(
-              '目標時間を設定',
+              l10n?.setTargetTimeTitle ?? 'Set Target Time',
               style: TextConsts.h3.copyWith(fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: SpacingConsts.l),
@@ -635,7 +657,7 @@ class _TimePickerDialogState extends State<_TimePickerDialog> {
                     ),
                   ),
                   Text(
-                    '時間',
+                    l10n?.hoursUnit ?? 'hours',
                     style: TextConsts.body.copyWith(
                       fontWeight: FontWeight.w600,
                     ),
@@ -676,7 +698,7 @@ class _TimePickerDialogState extends State<_TimePickerDialog> {
                     ),
                   ),
                   Text(
-                    '分',
+                    l10n?.minutesUnit ?? 'minutes',
                     style: TextConsts.body.copyWith(
                       fontWeight: FontWeight.w600,
                     ),
@@ -691,7 +713,7 @@ class _TimePickerDialogState extends State<_TimePickerDialog> {
                   child: TextButton(
                     onPressed: () => Navigator.of(context).pop(),
                     child: Text(
-                      'キャンセル',
+                      l10n?.commonBtnCancel ?? 'Cancel',
                       style: TextConsts.body.copyWith(
                         color: ColorConsts.textSecondary,
                       ),
@@ -720,9 +742,9 @@ class _TimePickerDialogState extends State<_TimePickerDialog> {
                         borderRadius: BorderRadius.circular(12),
                       ),
                     ),
-                    child: const Text(
-                      '決定',
-                      style: TextStyle(fontWeight: FontWeight.w600),
+                    child: Text(
+                      l10n?.btnConfirm ?? 'Confirm',
+                      style: const TextStyle(fontWeight: FontWeight.w600),
                     ),
                   ),
                 ),

--- a/lib/features/study_records/view/study_records_screen.dart
+++ b/lib/features/study_records/view/study_records_screen.dart
@@ -4,6 +4,7 @@ import 'package:get/get.dart';
 import '../../../core/utils/color_consts.dart';
 import '../../../core/utils/spacing_consts.dart';
 import '../../../core/utils/text_consts.dart';
+import '../../../l10n/app_localizations.dart';
 import '../view_model/study_records_view_model.dart';
 import 'widgets/daily_record_bottom_sheet.dart';
 import 'widgets/monthly_calendar.dart';
@@ -31,10 +32,12 @@ class _StudyRecordsScreenState extends State<StudyRecordsScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
     return Scaffold(
       backgroundColor: ColorConsts.backgroundPrimary,
       appBar: AppBar(
-        title: const Text('学習記録'),
+        title: Text(l10n?.studyRecordsTitle ?? 'Study Records'),
         backgroundColor: ColorConsts.cardBackground,
         foregroundColor: ColorConsts.textPrimary,
         elevation: 0,
@@ -55,7 +58,7 @@ class _StudyRecordsScreenState extends State<StudyRecordsScreen> {
                 const SizedBox(height: SpacingConsts.m),
                 _buildCalendarCard(viewModel, state),
                 const SizedBox(height: SpacingConsts.l),
-                _buildStreakInfo(state),
+                _buildStreakInfo(context, state),
                 const SizedBox(height: SpacingConsts.l),
               ],
             ),
@@ -89,7 +92,7 @@ class _StudyRecordsScreenState extends State<StudyRecordsScreen> {
             ),
           ),
           Text(
-            _formatMonth(state.currentMonth),
+            _formatMonth(context, state.currentMonth),
             style: TextConsts.h3.copyWith(fontWeight: FontWeight.w600),
           ),
           IconButton(
@@ -135,7 +138,9 @@ class _StudyRecordsScreenState extends State<StudyRecordsScreen> {
   }
 
   /// ストリーク情報
-  Widget _buildStreakInfo(StudyRecordsState state) {
+  Widget _buildStreakInfo(BuildContext context, StudyRecordsState state) {
+    final l10n = AppLocalizations.of(context);
+
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: SpacingConsts.l),
       padding: const EdgeInsets.all(SpacingConsts.m),
@@ -154,16 +159,16 @@ class _StudyRecordsScreenState extends State<StudyRecordsScreen> {
         children: [
           Expanded(
             child: _buildStreakItem(
-              title: '現在のストリーク',
-              value: '${state.currentStreak}日',
+              title: l10n?.currentStreakLabel ?? 'Current Streak',
+              value: l10n?.daysSuffix(state.currentStreak) ?? '${state.currentStreak} days',
               icon: '🔥',
             ),
           ),
           Container(width: 1, height: 48, color: ColorConsts.disabled),
           Expanded(
             child: _buildStreakItem(
-              title: '最長ストリーク',
-              value: '${state.longestStreak}日',
+              title: l10n?.longestStreakLabel ?? 'Longest Streak',
+              value: l10n?.daysSuffix(state.longestStreak) ?? '${state.longestStreak} days',
               icon: '🏆',
             ),
           ),
@@ -201,8 +206,9 @@ class _StudyRecordsScreenState extends State<StudyRecordsScreen> {
   }
 
   /// 月をフォーマット
-  String _formatMonth(DateTime date) {
-    return '${date.year}年${date.month}月';
+  String _formatMonth(BuildContext context, DateTime date) {
+    final l10n = AppLocalizations.of(context);
+    return l10n?.monthFormat(date.year, date.month) ?? '${date.year}/${date.month}';
   }
 
   /// 日別学習記録を表示

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -373,5 +373,166 @@
   "btnComplete": "Complete",
   "@btnComplete": {
     "description": "Complete button text"
+  },
+
+  "studyRecordsTitle": "Study Records",
+  "@studyRecordsTitle": {
+    "description": "Study records screen title"
+  },
+
+  "monthFormat": "{year}/{month}",
+  "@monthFormat": {
+    "description": "Month format for calendar navigation",
+    "placeholders": {
+      "year": {
+        "type": "int"
+      },
+      "month": {
+        "type": "int"
+      }
+    }
+  },
+
+  "currentStreakLabel": "Current Streak",
+  "@currentStreakLabel": {
+    "description": "Current streak label"
+  },
+
+  "longestStreakLabel": "Longest Streak",
+  "@longestStreakLabel": {
+    "description": "Longest streak label"
+  },
+
+  "addGoalTitle": "Add Goal",
+  "@addGoalTitle": {
+    "description": "Add goal modal title"
+  },
+
+  "editGoalTitle": "Edit Goal",
+  "@editGoalTitle": {
+    "description": "Edit goal modal title"
+  },
+
+  "goalAddedMessage": "Goal added",
+  "@goalAddedMessage": {
+    "description": "Success message when goal is added"
+  },
+
+  "goalUpdatedMessage": "Goal updated",
+  "@goalUpdatedMessage": {
+    "description": "Success message when goal is updated"
+  },
+
+  "goalAddFailedMessage": "Failed to add goal",
+  "@goalAddFailedMessage": {
+    "description": "Error message when goal addition fails"
+  },
+
+  "goalUpdateFailedMessage": "Failed to update goal",
+  "@goalUpdateFailedMessage": {
+    "description": "Error message when goal update fails"
+  },
+
+  "selectDeadlineValidation": "Please select a deadline",
+  "@selectDeadlineValidation": {
+    "description": "Validation message for deadline selection"
+  },
+
+  "goalNameLabel": "Goal Name *",
+  "@goalNameLabel": {
+    "description": "Goal name field label"
+  },
+
+  "descriptionLabel": "Description",
+  "@descriptionLabel": {
+    "description": "Description field label"
+  },
+
+  "targetMinutesLabel": "Daily Study Time *",
+  "@targetMinutesLabel": {
+    "description": "Target minutes field label"
+  },
+
+  "deadlineLabel": "Deadline *",
+  "@deadlineLabel": {
+    "description": "Deadline field label"
+  },
+
+  "avoidMessageLabel": "What happens if you don't achieve it? *",
+  "@avoidMessageLabel": {
+    "description": "Avoid message field label"
+  },
+
+  "avoidMessageHint": "Clarifying negative outcomes helps maintain motivation",
+  "@avoidMessageHint": {
+    "description": "Hint text for avoid message field"
+  },
+
+  "goalNameRequired": "Please enter a goal name",
+  "@goalNameRequired": {
+    "description": "Validation message for required goal name"
+  },
+
+  "avoidMessageRequired": "Please enter what happens if you don't achieve it",
+  "@avoidMessageRequired": {
+    "description": "Validation message for required avoid message"
+  },
+
+  "goalNamePlaceholder": "e.g. Get TOEIC 800",
+  "@goalNamePlaceholder": {
+    "description": "Placeholder for goal name field"
+  },
+
+  "descriptionPlaceholder": "e.g. I want to improve my English for working abroad",
+  "@descriptionPlaceholder": {
+    "description": "Placeholder for description field"
+  },
+
+  "avoidMessagePlaceholder": "e.g. Miss career advancement opportunities",
+  "@avoidMessagePlaceholder": {
+    "description": "Placeholder for avoid message field"
+  },
+
+  "selectDeadlinePlaceholder": "Select a deadline",
+  "@selectDeadlinePlaceholder": {
+    "description": "Placeholder for deadline selection"
+  },
+
+  "setTargetTimeTitle": "Set Target Time",
+  "@setTargetTimeTitle": {
+    "description": "Time picker dialog title"
+  },
+
+  "hoursUnit": "hours",
+  "@hoursUnit": {
+    "description": "Hours unit label"
+  },
+
+  "minutesUnit": "minutes",
+  "@minutesUnit": {
+    "description": "Minutes unit label"
+  },
+
+  "btnConfirm": "Confirm",
+  "@btnConfirm": {
+    "description": "Confirm button text"
+  },
+
+  "btnUpdate": "Update",
+  "@btnUpdate": {
+    "description": "Update button text"
+  },
+
+  "remainingDaysInfo": "{days} days left → Total target: {time}",
+  "@remainingDaysInfo": {
+    "description": "Remaining days and total target time info",
+    "placeholders": {
+      "days": {
+        "type": "int"
+      },
+      "time": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -121,5 +121,63 @@
 
   "dialogModeSwitchMessage": "タイマーを保存またはリセットしてからモードを切り替えてください",
 
-  "btnComplete": "完了"
+  "btnComplete": "完了",
+
+  "studyRecordsTitle": "学習記録",
+
+  "monthFormat": "{year}年{month}月",
+
+  "currentStreakLabel": "現在のストリーク",
+
+  "longestStreakLabel": "最長ストリーク",
+
+  "addGoalTitle": "目標を追加",
+
+  "editGoalTitle": "目標を編集",
+
+  "goalAddedMessage": "目標を追加しました",
+
+  "goalUpdatedMessage": "目標を更新しました",
+
+  "goalAddFailedMessage": "目標の追加に失敗しました",
+
+  "goalUpdateFailedMessage": "目標の更新に失敗しました",
+
+  "selectDeadlineValidation": "期限を選択してください",
+
+  "goalNameLabel": "目標名 *",
+
+  "descriptionLabel": "説明",
+
+  "targetMinutesLabel": "1日の勉強時間 *",
+
+  "deadlineLabel": "期限 *",
+
+  "avoidMessageLabel": "達成しないとどうなりますか？ *",
+
+  "avoidMessageHint": "ネガティブな結果を明確にすることで、モチベーションを維持しやすくなります",
+
+  "goalNameRequired": "目標名を入力してください",
+
+  "avoidMessageRequired": "達成しない場合の結果を入力してください",
+
+  "goalNamePlaceholder": "例: TOEIC 800点取得",
+
+  "descriptionPlaceholder": "例: 海外転職のために英語力を向上させたい",
+
+  "avoidMessagePlaceholder": "例: キャリアアップの機会を逃してしまう",
+
+  "selectDeadlinePlaceholder": "期限を選択してください",
+
+  "setTargetTimeTitle": "目標時間を設定",
+
+  "hoursUnit": "時間",
+
+  "minutesUnit": "分",
+
+  "btnConfirm": "決定",
+
+  "btnUpdate": "更新",
+
+  "remainingDaysInfo": "残り{days}日 → 総目標時間: {time}"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -463,6 +463,180 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Complete'**
   String get btnComplete;
+
+  /// Study records screen title
+  ///
+  /// In en, this message translates to:
+  /// **'Study Records'**
+  String get studyRecordsTitle;
+
+  /// Month format for calendar navigation
+  ///
+  /// In en, this message translates to:
+  /// **'{year}/{month}'**
+  String monthFormat(int year, int month);
+
+  /// Current streak label
+  ///
+  /// In en, this message translates to:
+  /// **'Current Streak'**
+  String get currentStreakLabel;
+
+  /// Longest streak label
+  ///
+  /// In en, this message translates to:
+  /// **'Longest Streak'**
+  String get longestStreakLabel;
+
+  /// Add goal modal title
+  ///
+  /// In en, this message translates to:
+  /// **'Add Goal'**
+  String get addGoalTitle;
+
+  /// Edit goal modal title
+  ///
+  /// In en, this message translates to:
+  /// **'Edit Goal'**
+  String get editGoalTitle;
+
+  /// Success message when goal is added
+  ///
+  /// In en, this message translates to:
+  /// **'Goal added'**
+  String get goalAddedMessage;
+
+  /// Success message when goal is updated
+  ///
+  /// In en, this message translates to:
+  /// **'Goal updated'**
+  String get goalUpdatedMessage;
+
+  /// Error message when goal addition fails
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to add goal'**
+  String get goalAddFailedMessage;
+
+  /// Error message when goal update fails
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to update goal'**
+  String get goalUpdateFailedMessage;
+
+  /// Validation message for deadline selection
+  ///
+  /// In en, this message translates to:
+  /// **'Please select a deadline'**
+  String get selectDeadlineValidation;
+
+  /// Goal name field label
+  ///
+  /// In en, this message translates to:
+  /// **'Goal Name *'**
+  String get goalNameLabel;
+
+  /// Description field label
+  ///
+  /// In en, this message translates to:
+  /// **'Description'**
+  String get descriptionLabel;
+
+  /// Target minutes field label
+  ///
+  /// In en, this message translates to:
+  /// **'Daily Study Time *'**
+  String get targetMinutesLabel;
+
+  /// Deadline field label
+  ///
+  /// In en, this message translates to:
+  /// **'Deadline *'**
+  String get deadlineLabel;
+
+  /// Avoid message field label
+  ///
+  /// In en, this message translates to:
+  /// **'What happens if you don\'t achieve it? *'**
+  String get avoidMessageLabel;
+
+  /// Hint text for avoid message field
+  ///
+  /// In en, this message translates to:
+  /// **'Clarifying negative outcomes helps maintain motivation'**
+  String get avoidMessageHint;
+
+  /// Validation message for required goal name
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter a goal name'**
+  String get goalNameRequired;
+
+  /// Validation message for required avoid message
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter what happens if you don\'t achieve it'**
+  String get avoidMessageRequired;
+
+  /// Placeholder for goal name field
+  ///
+  /// In en, this message translates to:
+  /// **'e.g. Get TOEIC 800'**
+  String get goalNamePlaceholder;
+
+  /// Placeholder for description field
+  ///
+  /// In en, this message translates to:
+  /// **'e.g. I want to improve my English for working abroad'**
+  String get descriptionPlaceholder;
+
+  /// Placeholder for avoid message field
+  ///
+  /// In en, this message translates to:
+  /// **'e.g. Miss career advancement opportunities'**
+  String get avoidMessagePlaceholder;
+
+  /// Placeholder for deadline selection
+  ///
+  /// In en, this message translates to:
+  /// **'Select a deadline'**
+  String get selectDeadlinePlaceholder;
+
+  /// Time picker dialog title
+  ///
+  /// In en, this message translates to:
+  /// **'Set Target Time'**
+  String get setTargetTimeTitle;
+
+  /// Hours unit label
+  ///
+  /// In en, this message translates to:
+  /// **'hours'**
+  String get hoursUnit;
+
+  /// Minutes unit label
+  ///
+  /// In en, this message translates to:
+  /// **'minutes'**
+  String get minutesUnit;
+
+  /// Confirm button text
+  ///
+  /// In en, this message translates to:
+  /// **'Confirm'**
+  String get btnConfirm;
+
+  /// Update button text
+  ///
+  /// In en, this message translates to:
+  /// **'Update'**
+  String get btnUpdate;
+
+  /// Remaining days and total target time info
+  ///
+  /// In en, this message translates to:
+  /// **'{days} days left → Total target: {time}'**
+  String remainingDaysInfo(int days, String time);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -242,4 +242,99 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get btnComplete => 'Complete';
+
+  @override
+  String get studyRecordsTitle => 'Study Records';
+
+  @override
+  String monthFormat(int year, int month) {
+    return '$year/$month';
+  }
+
+  @override
+  String get currentStreakLabel => 'Current Streak';
+
+  @override
+  String get longestStreakLabel => 'Longest Streak';
+
+  @override
+  String get addGoalTitle => 'Add Goal';
+
+  @override
+  String get editGoalTitle => 'Edit Goal';
+
+  @override
+  String get goalAddedMessage => 'Goal added';
+
+  @override
+  String get goalUpdatedMessage => 'Goal updated';
+
+  @override
+  String get goalAddFailedMessage => 'Failed to add goal';
+
+  @override
+  String get goalUpdateFailedMessage => 'Failed to update goal';
+
+  @override
+  String get selectDeadlineValidation => 'Please select a deadline';
+
+  @override
+  String get goalNameLabel => 'Goal Name *';
+
+  @override
+  String get descriptionLabel => 'Description';
+
+  @override
+  String get targetMinutesLabel => 'Daily Study Time *';
+
+  @override
+  String get deadlineLabel => 'Deadline *';
+
+  @override
+  String get avoidMessageLabel => 'What happens if you don\'t achieve it? *';
+
+  @override
+  String get avoidMessageHint =>
+      'Clarifying negative outcomes helps maintain motivation';
+
+  @override
+  String get goalNameRequired => 'Please enter a goal name';
+
+  @override
+  String get avoidMessageRequired =>
+      'Please enter what happens if you don\'t achieve it';
+
+  @override
+  String get goalNamePlaceholder => 'e.g. Get TOEIC 800';
+
+  @override
+  String get descriptionPlaceholder =>
+      'e.g. I want to improve my English for working abroad';
+
+  @override
+  String get avoidMessagePlaceholder =>
+      'e.g. Miss career advancement opportunities';
+
+  @override
+  String get selectDeadlinePlaceholder => 'Select a deadline';
+
+  @override
+  String get setTargetTimeTitle => 'Set Target Time';
+
+  @override
+  String get hoursUnit => 'hours';
+
+  @override
+  String get minutesUnit => 'minutes';
+
+  @override
+  String get btnConfirm => 'Confirm';
+
+  @override
+  String get btnUpdate => 'Update';
+
+  @override
+  String remainingDaysInfo(int days, String time) {
+    return '$days days left → Total target: $time';
+  }
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -214,4 +214,95 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get btnComplete => '完了';
+
+  @override
+  String get studyRecordsTitle => '学習記録';
+
+  @override
+  String monthFormat(int year, int month) {
+    return '$year年$month月';
+  }
+
+  @override
+  String get currentStreakLabel => '現在のストリーク';
+
+  @override
+  String get longestStreakLabel => '最長ストリーク';
+
+  @override
+  String get addGoalTitle => '目標を追加';
+
+  @override
+  String get editGoalTitle => '目標を編集';
+
+  @override
+  String get goalAddedMessage => '目標を追加しました';
+
+  @override
+  String get goalUpdatedMessage => '目標を更新しました';
+
+  @override
+  String get goalAddFailedMessage => '目標の追加に失敗しました';
+
+  @override
+  String get goalUpdateFailedMessage => '目標の更新に失敗しました';
+
+  @override
+  String get selectDeadlineValidation => '期限を選択してください';
+
+  @override
+  String get goalNameLabel => '目標名 *';
+
+  @override
+  String get descriptionLabel => '説明';
+
+  @override
+  String get targetMinutesLabel => '1日の勉強時間 *';
+
+  @override
+  String get deadlineLabel => '期限 *';
+
+  @override
+  String get avoidMessageLabel => '達成しないとどうなりますか？ *';
+
+  @override
+  String get avoidMessageHint => 'ネガティブな結果を明確にすることで、モチベーションを維持しやすくなります';
+
+  @override
+  String get goalNameRequired => '目標名を入力してください';
+
+  @override
+  String get avoidMessageRequired => '達成しない場合の結果を入力してください';
+
+  @override
+  String get goalNamePlaceholder => '例: TOEIC 800点取得';
+
+  @override
+  String get descriptionPlaceholder => '例: 海外転職のために英語力を向上させたい';
+
+  @override
+  String get avoidMessagePlaceholder => '例: キャリアアップの機会を逃してしまう';
+
+  @override
+  String get selectDeadlinePlaceholder => '期限を選択してください';
+
+  @override
+  String get setTargetTimeTitle => '目標時間を設定';
+
+  @override
+  String get hoursUnit => '時間';
+
+  @override
+  String get minutesUnit => '分';
+
+  @override
+  String get btnConfirm => '決定';
+
+  @override
+  String get btnUpdate => '更新';
+
+  @override
+  String remainingDaysInfo(int days, String time) {
+    return '残り$days日 → 総目標時間: $time';
+  }
 }


### PR DESCRIPTION
## Summary
- study_records_screen.dartの国際化（AppBarタイトル、月表示フォーマット、ストリーク情報）
- add_goal_modal.dartの国際化（StringConstsへの依存を全て削除）
- ARBファイルに26個の翻訳キーを追加

## Test plan
- [ ] 学習記録画面のタイトルが言語設定に応じて切り替わること
- [ ] 月表示が「2024年1月」/「2024/1」形式で正しく表示されること
- [ ] ストリークラベルが言語設定に応じて切り替わること
- [ ] 目標追加モーダルの全テキストが国際化されていること
- [ ] タイムピッカーダイアログが国際化されていること
- [ ] 全323テストが通過すること
- [ ] flutter analyzeでエラーがないこと
- [ ] IPAビルドが成功すること

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)