### PR TITLE
fix(settings): pubspec.yamlからバージョンを自動取得

### DIFF
--- a/lib/core/utils/app_consts.dart
+++ b/lib/core/utils/app_consts.dart
@@ -19,9 +19,6 @@ class AppConsts {
   /// アプリ名
   static const String appName = '目標達成タイマー';
 
-  /// アプリバージョン
-  static const String appVersion = '1.0.0';
-
   // === フィードバック設定 ===
   /// フィードバックポップアップの表示間隔（学習完了回数）
   static const int feedbackPopupInterval = 3;

--- a/lib/features/settings/view/settings_screen.dart
+++ b/lib/features/settings/view/settings_screen.dart
@@ -458,13 +458,16 @@ class _SettingsScreenState extends State<SettingsScreen>
           iconColor: ColorConsts.warning,
           onTap: _showFeatureRequestForm,
         ),
-        SettingItem(
-          title: l10n?.aboutApp ?? 'About',
-          subtitle: l10n?.versionLabel(AppConsts.appVersion) ?? 'Version ${AppConsts.appVersion}',
-          icon: Icons.info_outline,
-          iconColor: ColorConsts.textSecondary,
-          onTap: _showAbout,
-        ),
+        Obx(() {
+          final version = _settingsViewModel.appVersion.value;
+          return SettingItem(
+            title: l10n?.aboutApp ?? 'About',
+            subtitle: l10n?.versionLabel(version) ?? 'Version $version',
+            icon: Icons.info_outline,
+            iconColor: ColorConsts.textSecondary,
+            onTap: _showAbout,
+          );
+        }),
       ],
     );
   }
@@ -868,6 +871,7 @@ class _SettingsScreenState extends State<SettingsScreen>
   }
 
   void _showAbout() {
+    final version = _settingsViewModel.appVersion.value;
     showDialog(
       context: context,
       builder: (dialogContext) {
@@ -883,7 +887,7 @@ class _SettingsScreenState extends State<SettingsScreen>
                 style: TextConsts.h3.copyWith(fontWeight: FontWeight.bold),
               ),
               const SizedBox(height: SpacingConsts.s),
-              Text(dialogL10n?.versionLabel(AppConsts.appVersion) ?? 'Version: ${AppConsts.appVersion}'),
+              Text(dialogL10n?.versionLabel(version) ?? 'Version: $version'),
               const SizedBox(height: SpacingConsts.m),
               Text(dialogL10n?.aboutDialogDescription ?? 'A timer app to help you achieve your goals. Small daily efforts lead to great results.'),
             ],

--- a/lib/features/settings/view_model/settings_view_model.dart
+++ b/lib/features/settings/view_model/settings_view_model.dart
@@ -1,4 +1,5 @@
 import 'package:get/get.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../../core/data/local/local_settings_datasource.dart';
@@ -26,6 +27,7 @@ class SettingsViewModel extends GetxController {
       StreakReminderConsts.defaultReminderEnabled.obs;
   final RxString displayName = UserConsts.defaultGuestName.obs;
   final RxBool isUpdatingDisplayName = false.obs;
+  final RxString appVersion = ''.obs;
 
   /// Repositoryに渡す用のユーザーID（nullの場合は空文字）
   ///
@@ -61,6 +63,10 @@ class SettingsViewModel extends GetxController {
 
     final name = await _usersRepository.getDisplayName(userId);
     displayName.value = name;
+
+    // pubspec.yamlからバージョンを取得
+    final packageInfo = await PackageInfo.fromPlatform();
+    appVersion.value = packageInfo.version;
   }
 
   /// デフォルトタイマー時間を更新

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   jwt_decoder: ^2.0.1
   local_auth: ^3.0.0
   logger: ^2.6.2
+  package_info_plus: ^9.0.0
   path: '1.9.1'
   path_provider: ^2.1.5
   purchases_flutter: ^9.0.0

--- a/test/features/timer/view_model/timer_view_model_test.dart
+++ b/test/features/timer/view_model/timer_view_model_test.dart
@@ -37,6 +37,9 @@ class FakeSettingsViewModel extends GetxController
   final RxBool isUpdatingDisplayName = false.obs;
 
   @override
+  final RxString appVersion = '1.0.0'.obs;
+
+  @override
   Future<void> init() async {}
 
   @override


### PR DESCRIPTION
## Summary
- `package_info_plus`パッケージを導入し、pubspec.yamlのバージョンを実行時に自動取得
- 設定画面のバージョン表示を手動更新から自動取得に変更
- `AppConsts.appVersion`を削除（更新忘れ防止）

## Test plan
- [x] `flutter analyze` - Lintチェック通過
- [x] `flutter test` - 323件全テスト通過
- [x] `flutter build ios --release --no-codesign` - ビルド成功
- [ ] 設定画面でバージョンが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)