### PR TITLE
feat(manual-entry): 学習時間の手動入力機能を追加 #197

### DIFF
--- a/lib/core/utils/calendar_utils.dart
+++ b/lib/core/utils/calendar_utils.dart
@@ -1,0 +1,70 @@
+import 'package:intl/intl.dart';
+
+/// カレンダー表示で使用するロケール対応のユーティリティ
+class CalendarUtils {
+  /// ロケールに応じた短縮曜日リスト（週の開始曜日順）を取得する
+  ///
+  /// 例:
+  /// - ja: ['月', '火', '水', '木', '金', '土', '日']
+  /// - en_US: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+  static List<String> getOrderedWeekdays(String locale) {
+    final df = DateFormat('', locale);
+    final symbols = df.dateSymbols;
+    final narrowWeekdays = symbols.SHORTWEEKDAYS;
+    final firstDayOfWeek = symbols.FIRSTDAYOFWEEK;
+
+    // SHORTWEEKDAYS は [Sun, Mon, Tue, ...] の順（index 0 = 日曜）
+    // FIRSTDAYOFWEEK は 0=月曜, 1=火曜, ..., 6=日曜 (intl仕様)
+    // → 実際の曜日index: (firstDayOfWeek + 1) % 7 が SHORTWEEKDAYS の開始index
+    final startIndex = (firstDayOfWeek + 1) % 7;
+
+    final ordered = <String>[];
+    for (var i = 0; i < 7; i++) {
+      ordered.add(narrowWeekdays[(startIndex + i) % 7]);
+    }
+    return ordered;
+  }
+
+  /// 指定された月の日付リストを、ロケールの週開始曜日に基づいて生成する
+  ///
+  /// 先頭の空白日はnullで埋められる
+  static List<DateTime?> generateCalendarDays({
+    required DateTime month,
+    required String locale,
+  }) {
+    final df = DateFormat('', locale);
+    final firstDayOfWeek = df.dateSymbols.FIRSTDAYOFWEEK;
+
+    final firstDayOfMonth = DateTime(month.year, month.month, 1);
+    final lastDayOfMonth = DateTime(month.year, month.month + 1, 0);
+
+    // DateTime.weekday: 1=月曜, 7=日曜
+    // intl FIRSTDAYOFWEEK: 0=月曜, 6=日曜
+    // weekdayを intl体系に変換: (DateTime.weekday - 1)
+    final firstWeekdayIntl = firstDayOfMonth.weekday - 1;
+
+    // 先頭の空白日数を計算
+    final leadingEmptyDays = (firstWeekdayIntl - firstDayOfWeek + 7) % 7;
+
+    final List<DateTime?> days = [];
+
+    for (var i = 0; i < leadingEmptyDays; i++) {
+      days.add(null);
+    }
+
+    for (var day = 1; day <= lastDayOfMonth.day; day++) {
+      days.add(DateTime(month.year, month.month, day));
+    }
+
+    return days;
+  }
+
+  /// ロケールに応じた年月フォーマット文字列を取得する
+  ///
+  /// 例:
+  /// - ja: '2026年3月'
+  /// - en: 'March 2026'
+  static String formatYearMonth(DateTime date, String locale) {
+    return DateFormat.yMMMM(locale).format(date);
+  }
+}

--- a/lib/features/home/view/home_screen.dart
+++ b/lib/features/home/view/home_screen.dart
@@ -560,18 +560,7 @@ class _TimerTabContentState extends State<_TimerTabContent> {
                         const SizedBox(height: SpacingConsts.l),
                         Expanded(
                           child: NotificationListener<ScrollNotification>(
-                            onNotification: (notification) {
-                              if (notification is ScrollStartNotification) {
-                                if (_isFabVisible) {
-                                  setState(() => _isFabVisible = false);
-                                }
-                              } else if (notification is ScrollEndNotification) {
-                                if (!_isFabVisible) {
-                                  setState(() => _isFabVisible = true);
-                                }
-                              }
-                              return false;
-                            },
+                            onNotification: _handleScrollNotification,
                             child: ListView.separated(
                               itemCount: goals.length,
                               separatorBuilder:
@@ -599,6 +588,16 @@ class _TimerTabContentState extends State<_TimerTabContent> {
         );
       },
     );
+  }
+
+  /// スクロール通知を処理してFABの表示/非表示を切り替える
+  bool _handleScrollNotification(ScrollNotification notification) {
+    if (notification is ScrollStartNotification && _isFabVisible) {
+      setState(() => _isFabVisible = false);
+    } else if (notification is ScrollEndNotification && !_isFabVisible) {
+      setState(() => _isFabVisible = true);
+    }
+    return false;
   }
 
   /// 手動入力用フローティングボタン

--- a/lib/features/home/view/home_screen.dart
+++ b/lib/features/home/view/home_screen.dart
@@ -14,6 +14,7 @@ import '../../../core/widgets/pressable_card.dart';
 import '../../../core/widgets/streak_card.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../analytics/view/analytics_screen.dart';
+import '../../manual_entry/view/manual_entry_modal.dart';
 import '../../settings/view/settings_screen.dart';
 import '../../study_records/view/study_records_screen.dart';
 import '../../timer/view/timer_screen.dart';
@@ -118,7 +119,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
       body: pages[_tabController.index],
       bottomNavigationBar: _buildBottomNavigationBar(),
       floatingActionButton:
-          _tabController.index <= 1 ? _buildFloatingActionButton() : null,
+          _tabController.index == 0 ? _buildFloatingActionButton() : null,
       floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
     );
   }
@@ -493,8 +494,15 @@ class _HomeTabContent extends StatelessWidget {
   }
 }
 
-class _TimerTabContent extends StatelessWidget {
+class _TimerTabContent extends StatefulWidget {
   const _TimerTabContent();
+
+  @override
+  State<_TimerTabContent> createState() => _TimerTabContentState();
+}
+
+class _TimerTabContentState extends State<_TimerTabContent> {
+  bool _isFabVisible = true;
 
   @override
   Widget build(BuildContext context) {
@@ -551,27 +559,120 @@ class _TimerTabContent extends StatelessWidget {
                         ),
                         const SizedBox(height: SpacingConsts.l),
                         Expanded(
-                          child: ListView.separated(
-                            itemCount: goals.length,
-                            separatorBuilder:
-                                (context, index) =>
-                                    const SizedBox(height: SpacingConsts.m),
-                            itemBuilder: (context, index) {
-                              final goal = goals[index];
-                              return _buildGoalTimerCard(
-                                context,
-                                goal,
-                                homeViewModel,
-                              );
+                          child: NotificationListener<ScrollNotification>(
+                            onNotification: (notification) {
+                              if (notification is ScrollStartNotification) {
+                                if (_isFabVisible) {
+                                  setState(() => _isFabVisible = false);
+                                }
+                              } else if (notification is ScrollEndNotification) {
+                                if (!_isFabVisible) {
+                                  setState(() => _isFabVisible = true);
+                                }
+                              }
+                              return false;
                             },
+                            child: ListView.separated(
+                              itemCount: goals.length,
+                              separatorBuilder:
+                                  (context, index) =>
+                                      const SizedBox(height: SpacingConsts.m),
+                              itemBuilder: (context, index) {
+                                final goal = goals[index];
+                                return _buildGoalTimerCard(
+                                  context,
+                                  goal,
+                                  homeViewModel,
+                                );
+                              },
+                            ),
                           ),
                         ),
                       ],
                     ),
                   ),
+          floatingActionButton: goals.isNotEmpty
+              ? _buildManualEntryFab(context, goals, homeViewModel)
+              : null,
+          floatingActionButtonLocation:
+              FloatingActionButtonLocation.centerFloat,
         );
       },
     );
+  }
+
+  /// 手動入力用フローティングボタン
+  Widget _buildManualEntryFab(
+    BuildContext context,
+    List<GoalsModel> goals,
+    HomeViewModel homeViewModel,
+  ) {
+    final l10n = AppLocalizations.of(context);
+
+    return AnimatedOpacity(
+      opacity: _isFabVisible ? 1.0 : 0.0,
+      duration: AnimationConsts.fast,
+      child: IgnorePointer(
+        ignoring: !_isFabVisible,
+        child: Container(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(28),
+            gradient: const LinearGradient(
+              colors: [ColorConsts.primary, ColorConsts.primaryLight],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: ColorConsts.primary.withValues(alpha: 0.4),
+                offset: const Offset(0, 8),
+                blurRadius: 24,
+                spreadRadius: 0,
+              ),
+            ],
+          ),
+          child: Material(
+            color: Colors.transparent,
+            child: InkWell(
+              borderRadius: BorderRadius.circular(28),
+              onTap: () => _showManualEntry(context, goals, homeViewModel),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: SpacingConsts.l,
+                  vertical: SpacingConsts.m,
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(Icons.edit, color: Colors.white, size: 20),
+                    const SizedBox(width: SpacingConsts.s),
+                    Text(
+                      l10n?.manualEntryButton ?? '手動で記録する',
+                      style: TextConsts.bodyMedium.copyWith(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// 手動入力モーダルを表示
+  Future<void> _showManualEntry(
+    BuildContext context,
+    List<GoalsModel> goals,
+    HomeViewModel homeViewModel,
+  ) async {
+    final result = await showManualEntryModal(context, goals: goals);
+    if (result == true) {
+      homeViewModel.reloadGoals();
+    }
   }
 
   Widget _buildGoalTimerCard(

--- a/lib/features/manual_entry/view/manual_entry_modal.dart
+++ b/lib/features/manual_entry/view/manual_entry_modal.dart
@@ -1,0 +1,596 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:get/get.dart';
+
+import '../../../core/models/goals/goals_model.dart';
+import '../../../core/utils/color_consts.dart';
+import '../../../core/utils/spacing_consts.dart';
+import '../../../core/utils/text_consts.dart';
+import '../../../core/utils/time_utils.dart';
+import '../../../core/utils/ui_consts.dart';
+import '../../../l10n/app_localizations.dart';
+import '../view_model/manual_entry_view_model.dart';
+
+/// 手動学習時間入力モーダルを表示する
+Future<bool?> showManualEntryModal(
+  BuildContext context, {
+  required List<GoalsModel> goals,
+}) {
+  return showModalBottomSheet<bool>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    builder: (context) => ManualEntryModal(goals: goals),
+  );
+}
+
+/// 手動学習時間入力モーダル
+class ManualEntryModal extends StatefulWidget {
+  final List<GoalsModel> goals;
+
+  const ManualEntryModal({super.key, required this.goals});
+
+  @override
+  State<ManualEntryModal> createState() => _ManualEntryModalState();
+}
+
+class _ManualEntryModalState extends State<ManualEntryModal> {
+  DateTime _displayMonth = DateTime.now();
+
+  @override
+  void initState() {
+    super.initState();
+    Get.put(ManualEntryViewModel());
+  }
+
+  @override
+  void dispose() {
+    Get.delete<ManualEntryViewModel>();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final keyboardHeight = MediaQuery.of(context).viewInsets.bottom;
+    final screenHeight = MediaQuery.of(context).size.height;
+    final maxHeight =
+        (screenHeight - keyboardHeight) * UIConsts.modalHeightFactor;
+
+    return Padding(
+      padding: EdgeInsets.only(bottom: keyboardHeight),
+      child: Container(
+        constraints: BoxConstraints(maxHeight: maxHeight),
+        decoration: const BoxDecoration(
+          color: ColorConsts.backgroundPrimary,
+          borderRadius: BorderRadius.only(
+            topLeft: Radius.circular(24),
+            topRight: Radius.circular(24),
+          ),
+        ),
+        child: SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _buildHeader(context),
+              Flexible(
+                child: GetBuilder<ManualEntryViewModel>(
+                  builder: (viewModel) {
+                    return SingleChildScrollView(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: SpacingConsts.l,
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          _buildGoalSelector(context, viewModel),
+                          const SizedBox(height: SpacingConsts.l),
+                          _buildTimePicker(context, viewModel),
+                          const SizedBox(height: SpacingConsts.l),
+                          _buildDateSelector(context, viewModel),
+                          const SizedBox(height: SpacingConsts.l),
+                          _buildSaveButton(context, viewModel),
+                          const SizedBox(height: SpacingConsts.l),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// ヘッダー（タイトル + 閉じるボタン）
+  Widget _buildHeader(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.all(SpacingConsts.m),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          const SizedBox(width: 40),
+          Text(
+            l10n?.manualEntryTitle ?? '手動で記録',
+            style: TextConsts.h4.copyWith(fontWeight: FontWeight.bold),
+          ),
+          IconButton(
+            onPressed: () => Navigator.pop(context),
+            icon: const Icon(Icons.close, color: ColorConsts.textSecondary),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 目標選択セクション
+  Widget _buildGoalSelector(
+    BuildContext context,
+    ManualEntryViewModel viewModel,
+  ) {
+    final l10n = AppLocalizations.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          l10n?.manualEntrySelectGoal ?? '目標を選択',
+          style: TextConsts.bodyMedium.copyWith(
+            fontWeight: FontWeight.w600,
+            color: ColorConsts.textPrimary,
+          ),
+        ),
+        const SizedBox(height: SpacingConsts.s),
+        ...widget.goals.map((goal) {
+          final isSelected = viewModel.selectedGoal?.id == goal.id;
+          return Padding(
+            padding: const EdgeInsets.only(bottom: SpacingConsts.s),
+            child: GestureDetector(
+              onTap: () => viewModel.selectGoal(goal),
+              child: Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(SpacingConsts.m),
+                decoration: BoxDecoration(
+                  color: isSelected
+                      ? ColorConsts.primary.withValues(alpha: 0.1)
+                      : ColorConsts.cardBackground,
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(
+                    color:
+                        isSelected ? ColorConsts.primary : ColorConsts.disabled,
+                    width: isSelected ? 2 : 1,
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    Icon(
+                      isSelected
+                          ? Icons.check_circle
+                          : Icons.radio_button_unchecked,
+                      color: isSelected
+                          ? ColorConsts.primary
+                          : ColorConsts.textTertiary,
+                      size: 20,
+                    ),
+                    const SizedBox(width: SpacingConsts.s),
+                    Expanded(
+                      child: Text(
+                        goal.title,
+                        style: TextConsts.bodyMedium.copyWith(
+                          fontWeight:
+                              isSelected ? FontWeight.w600 : FontWeight.normal,
+                          color: isSelected
+                              ? ColorConsts.primary
+                              : ColorConsts.textPrimary,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        }),
+      ],
+    );
+  }
+
+  /// 学習時間ピッカーセクション
+  Widget _buildTimePicker(
+    BuildContext context,
+    ManualEntryViewModel viewModel,
+  ) {
+    final l10n = AppLocalizations.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          l10n?.manualEntryStudyTime ?? '学習時間',
+          style: TextConsts.bodyMedium.copyWith(
+            fontWeight: FontWeight.w600,
+            color: ColorConsts.textPrimary,
+          ),
+        ),
+        const SizedBox(height: SpacingConsts.s),
+        Container(
+          height: 180,
+          decoration: BoxDecoration(
+            color: ColorConsts.cardBackground,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: ColorConsts.disabled),
+          ),
+          child: CupertinoTimerPicker(
+            mode: CupertinoTimerPickerMode.hm,
+            initialTimerDuration: viewModel.selectedDuration,
+            onTimerDurationChanged: (duration) {
+              viewModel.setDuration(duration);
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// 日付選択セクション（MonthlyCalendar風のカスタム実装）
+  Widget _buildDateSelector(
+    BuildContext context,
+    ManualEntryViewModel viewModel,
+  ) {
+    final l10n = AppLocalizations.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          l10n?.manualEntryStudyDate ?? '学習日',
+          style: TextConsts.bodyMedium.copyWith(
+            fontWeight: FontWeight.w600,
+            color: ColorConsts.textPrimary,
+          ),
+        ),
+        const SizedBox(height: SpacingConsts.s),
+        Container(
+          padding: const EdgeInsets.all(SpacingConsts.m),
+          decoration: BoxDecoration(
+            color: ColorConsts.cardBackground,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: ColorConsts.disabled),
+          ),
+          child: Column(
+            children: [
+              _buildMonthNavigation(),
+              const SizedBox(height: SpacingConsts.s),
+              _buildWeekdayHeader(),
+              const SizedBox(height: SpacingConsts.xs),
+              _buildCalendarGrid(viewModel),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// 月ナビゲーション（前月・次月ボタン）
+  Widget _buildMonthNavigation() {
+    final now = DateTime.now();
+    final isCurrentMonth = _displayMonth.year == now.year &&
+        _displayMonth.month == now.month;
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        IconButton(
+          onPressed: () {
+            setState(() {
+              _displayMonth = DateTime(
+                _displayMonth.year,
+                _displayMonth.month - 1,
+              );
+            });
+          },
+          icon: const Icon(Icons.chevron_left, color: ColorConsts.textSecondary),
+        ),
+        Text(
+          '${_displayMonth.year}年${_displayMonth.month}月',
+          style: TextConsts.bodyMedium.copyWith(fontWeight: FontWeight.w600),
+        ),
+        IconButton(
+          onPressed: isCurrentMonth
+              ? null
+              : () {
+                  setState(() {
+                    _displayMonth = DateTime(
+                      _displayMonth.year,
+                      _displayMonth.month + 1,
+                    );
+                  });
+                },
+          icon: Icon(
+            Icons.chevron_right,
+            color: isCurrentMonth
+                ? ColorConsts.disabled
+                : ColorConsts.textSecondary,
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// 曜日ヘッダー
+  Widget _buildWeekdayHeader() {
+    const weekdays = ['月', '火', '水', '木', '金', '土', '日'];
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceAround,
+      children: weekdays
+          .map(
+            (day) => SizedBox(
+              width: 40,
+              child: Center(
+                child: Text(
+                  day,
+                  style: TextConsts.bodySmall.copyWith(
+                    fontWeight: FontWeight.w500,
+                    color: ColorConsts.textSecondary,
+                  ),
+                ),
+              ),
+            ),
+          )
+          .toList(),
+    );
+  }
+
+  /// カレンダーグリッド
+  Widget _buildCalendarGrid(ManualEntryViewModel viewModel) {
+    final days = _generateCalendarDays();
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+
+    return GridView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 7,
+        mainAxisSpacing: 4,
+        crossAxisSpacing: 4,
+        childAspectRatio: 1,
+      ),
+      itemCount: days.length,
+      itemBuilder: (context, index) {
+        final day = days[index];
+        if (day == null) return const SizedBox.shrink();
+
+        final isToday = day.year == today.year &&
+            day.month == today.month &&
+            day.day == today.day;
+        final isFuture = day.isAfter(today);
+        final isSelected = day.year == viewModel.selectedDate.year &&
+            day.month == viewModel.selectedDate.month &&
+            day.day == viewModel.selectedDate.day;
+
+        return GestureDetector(
+          onTap: isFuture
+              ? null
+              : () {
+                  viewModel.setDate(day);
+                  setState(() {});
+                },
+          child: Container(
+            decoration: _getDayCellDecoration(
+              isToday: isToday,
+              isFuture: isFuture,
+              isSelected: isSelected,
+            ),
+            child: Center(
+              child: Text(
+                '${day.day}',
+                style: TextConsts.bodyMedium.copyWith(
+                  color: _getDayTextColor(
+                    isToday: isToday,
+                    isFuture: isFuture,
+                    isSelected: isSelected,
+                  ),
+                  fontWeight:
+                      (isToday || isSelected) ? FontWeight.w600 : null,
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  BoxDecoration _getDayCellDecoration({
+    required bool isToday,
+    required bool isFuture,
+    required bool isSelected,
+  }) {
+    if (isSelected) {
+      return BoxDecoration(
+        color: ColorConsts.primary,
+        borderRadius: BorderRadius.circular(8),
+      );
+    }
+    if (isToday) {
+      return BoxDecoration(
+        border: Border.all(color: ColorConsts.primary, width: 2),
+        borderRadius: BorderRadius.circular(8),
+      );
+    }
+    if (isFuture) {
+      return const BoxDecoration();
+    }
+    return const BoxDecoration();
+  }
+
+  Color _getDayTextColor({
+    required bool isToday,
+    required bool isFuture,
+    required bool isSelected,
+  }) {
+    if (isSelected) return Colors.white;
+    if (isFuture) return ColorConsts.textTertiary;
+    if (isToday) return ColorConsts.primary;
+    return ColorConsts.textPrimary;
+  }
+
+  List<DateTime?> _generateCalendarDays() {
+    final firstDayOfMonth =
+        DateTime(_displayMonth.year, _displayMonth.month, 1);
+    final lastDayOfMonth =
+        DateTime(_displayMonth.year, _displayMonth.month + 1, 0);
+    final leadingEmptyDays = firstDayOfMonth.weekday - 1;
+
+    final List<DateTime?> days = [];
+    for (var i = 0; i < leadingEmptyDays; i++) {
+      days.add(null);
+    }
+    for (var day = 1; day <= lastDayOfMonth.day; day++) {
+      days.add(DateTime(_displayMonth.year, _displayMonth.month, day));
+    }
+    return days;
+  }
+
+  /// 保存ボタン
+  Widget _buildSaveButton(
+    BuildContext context,
+    ManualEntryViewModel viewModel,
+  ) {
+    final l10n = AppLocalizations.of(context);
+
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton(
+        onPressed: viewModel.canSave ? () => _onSave(context, viewModel) : null,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: ColorConsts.primary,
+          foregroundColor: Colors.white,
+          disabledBackgroundColor: ColorConsts.disabled,
+          padding: const EdgeInsets.symmetric(vertical: SpacingConsts.m),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+          elevation: 0,
+        ),
+        child: viewModel.isSaving
+            ? const SizedBox(
+                width: 24,
+                height: 24,
+                child: CircularProgressIndicator(
+                  color: Colors.white,
+                  strokeWidth: 2,
+                ),
+              )
+            : Text(
+                l10n?.commonBtnSave ?? '保存',
+                style: TextConsts.bodyMedium.copyWith(
+                  color: Colors.white,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+      ),
+    );
+  }
+
+  /// 保存処理
+  Future<void> _onSave(
+    BuildContext context,
+    ManualEntryViewModel viewModel,
+  ) async {
+    final l10n = AppLocalizations.of(context);
+    final result = await viewModel.save();
+
+    if (!context.mounted) return;
+
+    if (result) {
+      // バイブレーション
+      HapticFeedback.mediumImpact();
+
+      // 達成演出表示
+      await _showCongratsDialog(context, viewModel);
+
+      if (!context.mounted) return;
+      Navigator.pop(context, true);
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(l10n?.manualEntrySaveFailed ?? '保存に失敗しました'),
+          backgroundColor: ColorConsts.error,
+        ),
+      );
+    }
+  }
+
+  /// 達成演出ダイアログ
+  Future<void> _showCongratsDialog(
+    BuildContext context,
+    ManualEntryViewModel viewModel,
+  ) async {
+    final l10n = AppLocalizations.of(context);
+    final duration = viewModel.selectedDuration;
+    final hours = duration.inHours;
+    final minutes = duration.inMinutes % TimeUtils.minutesPerHour;
+
+    String timeText;
+    if (l10n != null) {
+      timeText = l10n.timeFormatHoursMinutes(hours, minutes);
+    } else {
+      timeText = TimeUtils.formatMinutesToHoursAndMinutes(duration.inMinutes);
+    }
+
+    await showDialog<void>(
+      context: context,
+      barrierDismissible: true,
+      builder: (dialogContext) {
+        // 自動で閉じるタイマー
+        Future.delayed(const Duration(seconds: 2), () {
+          if (dialogContext.mounted) {
+            Navigator.of(dialogContext).pop();
+          }
+        });
+
+        return Dialog(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(SpacingConsts.xl),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(
+                  Icons.celebration,
+                  size: 64,
+                  color: ColorConsts.warning,
+                ),
+                const SizedBox(height: SpacingConsts.m),
+                Text(
+                  l10n?.manualEntryCongratsTitle ?? 'お疲れ様でした！',
+                  style: TextConsts.h3.copyWith(fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: SpacingConsts.s),
+                Text(
+                  l10n?.manualEntryCongratsMessage(timeText) ??
+                      '$timeTextの学習を記録しました',
+                  style: TextConsts.bodyMedium.copyWith(
+                    color: ColorConsts.textSecondary,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/manual_entry/view/manual_entry_modal.dart
+++ b/lib/features/manual_entry/view/manual_entry_modal.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 
 import '../../../core/models/goals/goals_model.dart';
+import '../../../core/utils/calendar_utils.dart';
 import '../../../core/utils/color_consts.dart';
 import '../../../core/utils/spacing_consts.dart';
 import '../../../core/utils/text_consts.dart';
@@ -298,7 +299,10 @@ class _ManualEntryModalState extends State<ManualEntryModal> {
           icon: const Icon(Icons.chevron_left, color: ColorConsts.textSecondary),
         ),
         Text(
-          '${_displayMonth.year}年${_displayMonth.month}月',
+          CalendarUtils.formatYearMonth(
+            _displayMonth,
+            Localizations.localeOf(context).toString(),
+          ),
           style: TextConsts.bodyMedium.copyWith(fontWeight: FontWeight.w600),
         ),
         IconButton(
@@ -323,9 +327,10 @@ class _ManualEntryModalState extends State<ManualEntryModal> {
     );
   }
 
-  /// 曜日ヘッダー
+  /// 曜日ヘッダー（ロケール対応）
   Widget _buildWeekdayHeader() {
-    const weekdays = ['月', '火', '水', '木', '金', '土', '日'];
+    final locale = Localizations.localeOf(context).toString();
+    final weekdays = CalendarUtils.getOrderedWeekdays(locale);
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceAround,
@@ -350,7 +355,11 @@ class _ManualEntryModalState extends State<ManualEntryModal> {
 
   /// カレンダーグリッド
   Widget _buildCalendarGrid(ManualEntryViewModel viewModel) {
-    final days = _generateCalendarDays();
+    final locale = Localizations.localeOf(context).toString();
+    final days = CalendarUtils.generateCalendarDays(
+      month: _displayMonth,
+      locale: locale,
+    );
     final now = DateTime.now();
     final today = DateTime(now.year, now.month, now.day);
 
@@ -441,23 +450,6 @@ class _ManualEntryModalState extends State<ManualEntryModal> {
     if (isFuture) return ColorConsts.textTertiary;
     if (isToday) return ColorConsts.primary;
     return ColorConsts.textPrimary;
-  }
-
-  List<DateTime?> _generateCalendarDays() {
-    final firstDayOfMonth =
-        DateTime(_displayMonth.year, _displayMonth.month, 1);
-    final lastDayOfMonth =
-        DateTime(_displayMonth.year, _displayMonth.month + 1, 0);
-    final leadingEmptyDays = firstDayOfMonth.weekday - 1;
-
-    final List<DateTime?> days = [];
-    for (var i = 0; i < leadingEmptyDays; i++) {
-      days.add(null);
-    }
-    for (var day = 1; day <= lastDayOfMonth.day; day++) {
-      days.add(DateTime(_displayMonth.year, _displayMonth.month, day));
-    }
-    return days;
   }
 
   /// 保存ボタン

--- a/lib/features/manual_entry/view_model/manual_entry_view_model.dart
+++ b/lib/features/manual_entry/view_model/manual_entry_view_model.dart
@@ -1,0 +1,162 @@
+import 'package:get/get.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../core/data/repositories/study_logs_repository.dart';
+import '../../../core/data/repositories/users_repository.dart';
+import '../../../core/models/goals/goals_model.dart';
+import '../../../core/models/study_daily_logs/study_daily_logs_model.dart';
+import '../../../core/services/auth_service.dart';
+import '../../../core/utils/app_logger.dart';
+import '../../../core/utils/streak_consts.dart';
+
+/// 手動学習時間入力のViewModel
+class ManualEntryViewModel extends GetxController {
+  final StudyLogsRepository _studyLogsRepository;
+  final UsersRepository _usersRepository;
+  final AuthService _authService;
+
+  /// 選択された目標
+  GoalsModel? _selectedGoal;
+  GoalsModel? get selectedGoal => _selectedGoal;
+
+  /// 選択された学習時間（Duration）
+  Duration _selectedDuration = Duration.zero;
+  Duration get selectedDuration => _selectedDuration;
+
+  /// 選択された学習日
+  DateTime _selectedDate = DateTime.now();
+  DateTime get selectedDate =>
+      DateTime(_selectedDate.year, _selectedDate.month, _selectedDate.day);
+
+  /// 保存中フラグ
+  bool _isSaving = false;
+  bool get isSaving => _isSaving;
+
+  /// 現在のユーザーID
+  String? get _userId => _authService.currentUserId;
+
+  /// Repositoryに渡す用のユーザーID（nullの場合は空文字）
+  String get _userIdForRepository => _authService.currentUserId ?? '';
+
+  /// コンストラクタ（DIパターン適用）
+  ManualEntryViewModel({
+    StudyLogsRepository? studyLogsRepository,
+    UsersRepository? usersRepository,
+    AuthService? authService,
+  })  : _studyLogsRepository = studyLogsRepository ?? StudyLogsRepository(),
+        _usersRepository = usersRepository ?? UsersRepository(),
+        _authService = authService ?? AuthService();
+
+  /// 目標を選択する
+  void selectGoal(GoalsModel goal) {
+    _selectedGoal = goal;
+    update();
+  }
+
+  /// 学習時間を設定する
+  void setDuration(Duration duration) {
+    _selectedDuration = duration;
+    update();
+  }
+
+  /// 学習日を設定する
+  void setDate(DateTime date) {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final dateOnly = DateTime(date.year, date.month, date.day);
+
+    // 未来の日付は設定不可
+    if (dateOnly.isAfter(today)) {
+      AppLogger.instance.w('未来の日付は選択できません: $date');
+      return;
+    }
+
+    _selectedDate = dateOnly;
+    update();
+  }
+
+  /// バリデーション: 目標が選択されているか
+  bool get isGoalSelected => _selectedGoal != null;
+
+  /// バリデーション: 学習時間が設定されているか（1分以上）
+  bool get isTimeSelected => _selectedDuration.inSeconds > 0;
+
+  /// バリデーション: 保存可能な状態か
+  bool get canSave => isGoalSelected && isTimeSelected && !_isSaving;
+
+  /// 学習記録を保存する
+  ///
+  /// 成功時はtrue、失敗時はfalseを返す
+  Future<bool> save() async {
+    if (!canSave) {
+      AppLogger.instance.w('保存条件を満たしていません');
+      return false;
+    }
+
+    _isSaving = true;
+    update();
+
+    try {
+      final log = StudyDailyLogsModel(
+        id: const Uuid().v4(),
+        goalId: _selectedGoal!.id,
+        studyDate: selectedDate,
+        totalSeconds: _selectedDuration.inSeconds,
+        userId: _userId,
+      );
+
+      await _studyLogsRepository.upsertLog(log);
+
+      AppLogger.instance.i(
+        '手動学習記録を保存しました: ${log.id}, '
+        '目標: ${_selectedGoal!.title}, '
+        '学習日: ${log.studyDate}, '
+        '${_selectedDuration.inSeconds}秒',
+      );
+
+      // 1分以上学習した場合のみストリーク処理を実行
+      if (_selectedDuration.inSeconds >= StreakConsts.minStudySeconds) {
+        await _updateLongestStreakIfNeeded();
+      }
+
+      _isSaving = false;
+      update();
+      return true;
+    } catch (error, stackTrace) {
+      AppLogger.instance.e('手動学習記録の保存に失敗しました', error, stackTrace);
+      _isSaving = false;
+      update();
+      return false;
+    }
+  }
+
+  /// ストリーク更新処理
+  Future<void> _updateLongestStreakIfNeeded() async {
+    try {
+      final userId = _userIdForRepository;
+
+      final currentStreak =
+          await _studyLogsRepository.calculateCurrentStreak(userId);
+
+      final updated = await _usersRepository.updateLongestStreakIfNeeded(
+        currentStreak,
+        userId,
+      );
+
+      if (updated) {
+        AppLogger.instance.i('最長ストリークを更新しました: $currentStreak日');
+      }
+    } catch (error, stackTrace) {
+      AppLogger.instance.e('最長ストリークの更新に失敗しました', error, stackTrace);
+    }
+  }
+
+  /// 状態をリセットする
+  void reset() {
+    _selectedGoal = null;
+    _selectedDuration = Duration.zero;
+    _selectedDate = DateTime.now();
+    _isSaving = false;
+    update();
+  }
+}

--- a/lib/features/manual_entry/view_model/manual_entry_view_model.dart
+++ b/lib/features/manual_entry/view_model/manual_entry_view_model.dart
@@ -97,9 +97,12 @@ class ManualEntryViewModel extends GetxController {
     update();
 
     try {
+      final goal = _selectedGoal;
+      if (goal == null) return false;
+
       final log = StudyDailyLogsModel(
         id: const Uuid().v4(),
-        goalId: _selectedGoal!.id,
+        goalId: goal.id,
         studyDate: selectedDate,
         totalSeconds: _selectedDuration.inSeconds,
         userId: _userId,
@@ -109,7 +112,7 @@ class ManualEntryViewModel extends GetxController {
 
       AppLogger.instance.i(
         '手動学習記録を保存しました: ${log.id}, '
-        '目標: ${_selectedGoal!.title}, '
+        '目標: ${goal.title}, '
         '学習日: ${log.studyDate}, '
         '${_selectedDuration.inSeconds}秒',
       );

--- a/lib/features/study_records/view/widgets/monthly_calendar.dart
+++ b/lib/features/study_records/view/widgets/monthly_calendar.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
+import '../../../../core/utils/calendar_utils.dart';
 import '../../../../core/utils/color_consts.dart';
 import '../../../../core/utils/spacing_consts.dart';
 import '../../../../core/utils/text_consts.dart';
 
-/// 月間カレンダーウィジェット（月曜始まり）
+/// 月間カレンダーウィジェット（ロケール対応）
 class MonthlyCalendar extends StatelessWidget {
   final DateTime currentMonth;
   final List<DateTime> studyDates;
@@ -25,11 +26,17 @@ class MonthlyCalendar extends StatelessWidget {
     // パフォーマンス改善: studyDatesをSetに変換してO(1)検索
     final studyDateSet = _createStudyDateSet();
 
+    final locale = Localizations.localeOf(context).toString();
+
     return Column(
       children: [
-        _buildWeekdayHeader(),
+        _buildWeekdayHeader(locale),
         const SizedBox(height: SpacingConsts.s),
-        _buildCalendarGrid(today: today, studyDateSet: studyDateSet),
+        _buildCalendarGrid(
+          today: today,
+          studyDateSet: studyDateSet,
+          locale: locale,
+        ),
       ],
     );
   }
@@ -39,9 +46,9 @@ class MonthlyCalendar extends StatelessWidget {
     return studyDates.map((d) => DateTime(d.year, d.month, d.day)).toSet();
   }
 
-  /// 曜日ヘッダー（月曜始まり）
-  Widget _buildWeekdayHeader() {
-    const weekdays = ['月', '火', '水', '木', '金', '土', '日'];
+  /// 曜日ヘッダー（ロケール対応）
+  Widget _buildWeekdayHeader(String locale) {
+    final weekdays = CalendarUtils.getOrderedWeekdays(locale);
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceAround,
@@ -67,8 +74,12 @@ class MonthlyCalendar extends StatelessWidget {
   Widget _buildCalendarGrid({
     required DateTime today,
     required Set<DateTime> studyDateSet,
+    required String locale,
   }) {
-    final days = _generateCalendarDays();
+    final days = CalendarUtils.generateCalendarDays(
+      month: currentMonth,
+      locale: locale,
+    );
 
     return GridView.builder(
       shrinkWrap: true,
@@ -191,37 +202,6 @@ class MonthlyCalendar extends StatelessWidget {
     }
 
     return ColorConsts.textPrimary;
-  }
-
-  /// カレンダーの日付リストを生成（月曜始まり）
-  List<DateTime?> _generateCalendarDays() {
-    final firstDayOfMonth = DateTime(currentMonth.year, currentMonth.month, 1);
-    final lastDayOfMonth = DateTime(
-      currentMonth.year,
-      currentMonth.month + 1,
-      0,
-    );
-
-    // 月曜始まりのため、1=月曜, 7=日曜に変換
-    // DateTime.weekdayは1=月曜, 7=日曜なので調整不要
-    final startWeekday = firstDayOfMonth.weekday;
-
-    // 月曜始まりなので、月曜=1から始まる
-    final leadingEmptyDays = startWeekday - 1;
-
-    final List<DateTime?> days = [];
-
-    // 前月の空白
-    for (var i = 0; i < leadingEmptyDays; i++) {
-      days.add(null);
-    }
-
-    // 当月の日付
-    for (var day = 1; day <= lastDayOfMonth.day; day++) {
-      days.add(DateTime(currentMonth.year, currentMonth.month, day));
-    }
-
-    return days;
   }
 
   /// 今日かどうか

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1155,5 +1155,65 @@
         "type": "String"
       }
     }
+  },
+
+  "manualEntryButton": "Record Manually",
+  "@manualEntryButton": {
+    "description": "Manual entry floating button text"
+  },
+
+  "manualEntryTitle": "Manual Record",
+  "@manualEntryTitle": {
+    "description": "Manual entry modal title"
+  },
+
+  "manualEntrySelectGoal": "Select Goal",
+  "@manualEntrySelectGoal": {
+    "description": "Manual entry goal selection label"
+  },
+
+  "manualEntryStudyTime": "Study Time",
+  "@manualEntryStudyTime": {
+    "description": "Manual entry study time label"
+  },
+
+  "manualEntryStudyDate": "Study Date",
+  "@manualEntryStudyDate": {
+    "description": "Manual entry study date label"
+  },
+
+  "manualEntryNoGoalSelected": "Please select a goal",
+  "@manualEntryNoGoalSelected": {
+    "description": "Validation message when no goal is selected"
+  },
+
+  "manualEntryNoTimeSelected": "Please set a study time",
+  "@manualEntryNoTimeSelected": {
+    "description": "Validation message when no time is set"
+  },
+
+  "manualEntrySaveSuccess": "Study record saved!",
+  "@manualEntrySaveSuccess": {
+    "description": "Success message after manual entry save"
+  },
+
+  "manualEntrySaveFailed": "Failed to save",
+  "@manualEntrySaveFailed": {
+    "description": "Error message when manual entry save fails"
+  },
+
+  "manualEntryCongratsTitle": "Great job!",
+  "@manualEntryCongratsTitle": {
+    "description": "Congratulations title after manual entry save"
+  },
+
+  "manualEntryCongratsMessage": "Recorded {time} of study",
+  "@manualEntryCongratsMessage": {
+    "description": "Congratulations message after manual entry save",
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -403,5 +403,27 @@
 
   "repeatingNotificationTitle": "学習時間終了",
 
-  "repeatingNotificationMessage": "「{goal}」の学習時間（{duration}）を達成しました！お疲れ様です！"
+  "repeatingNotificationMessage": "「{goal}」の学習時間（{duration}）を達成しました！お疲れ様です！",
+
+  "manualEntryButton": "手動で記録する",
+
+  "manualEntryTitle": "手動で記録",
+
+  "manualEntrySelectGoal": "目標を選択",
+
+  "manualEntryStudyTime": "学習時間",
+
+  "manualEntryStudyDate": "学習日",
+
+  "manualEntryNoGoalSelected": "目標を選択してください",
+
+  "manualEntryNoTimeSelected": "学習時間を設定してください",
+
+  "manualEntrySaveSuccess": "学習記録を保存しました！",
+
+  "manualEntrySaveFailed": "保存に失敗しました",
+
+  "manualEntryCongratsTitle": "お疲れ様でした！",
+
+  "manualEntryCongratsMessage": "{time}の学習を記録しました"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1309,6 +1309,72 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'You completed {duration} of studying \"{goal}\"! Great job!'**
   String repeatingNotificationMessage(String goal, String duration);
+
+  /// Manual entry floating button text
+  ///
+  /// In en, this message translates to:
+  /// **'Record Manually'**
+  String get manualEntryButton;
+
+  /// Manual entry modal title
+  ///
+  /// In en, this message translates to:
+  /// **'Manual Record'**
+  String get manualEntryTitle;
+
+  /// Manual entry goal selection label
+  ///
+  /// In en, this message translates to:
+  /// **'Select Goal'**
+  String get manualEntrySelectGoal;
+
+  /// Manual entry study time label
+  ///
+  /// In en, this message translates to:
+  /// **'Study Time'**
+  String get manualEntryStudyTime;
+
+  /// Manual entry study date label
+  ///
+  /// In en, this message translates to:
+  /// **'Study Date'**
+  String get manualEntryStudyDate;
+
+  /// Validation message when no goal is selected
+  ///
+  /// In en, this message translates to:
+  /// **'Please select a goal'**
+  String get manualEntryNoGoalSelected;
+
+  /// Validation message when no time is set
+  ///
+  /// In en, this message translates to:
+  /// **'Please set a study time'**
+  String get manualEntryNoTimeSelected;
+
+  /// Success message after manual entry save
+  ///
+  /// In en, this message translates to:
+  /// **'Study record saved!'**
+  String get manualEntrySaveSuccess;
+
+  /// Error message when manual entry save fails
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to save'**
+  String get manualEntrySaveFailed;
+
+  /// Congratulations title after manual entry save
+  ///
+  /// In en, this message translates to:
+  /// **'Great job!'**
+  String get manualEntryCongratsTitle;
+
+  /// Congratulations message after manual entry save
+  ///
+  /// In en, this message translates to:
+  /// **'Recorded {time} of study'**
+  String manualEntryCongratsMessage(String time);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -714,4 +714,39 @@ class AppLocalizationsEn extends AppLocalizations {
   String repeatingNotificationMessage(String goal, String duration) {
     return 'You completed $duration of studying \"$goal\"! Great job!';
   }
+
+  @override
+  String get manualEntryButton => 'Record Manually';
+
+  @override
+  String get manualEntryTitle => 'Manual Record';
+
+  @override
+  String get manualEntrySelectGoal => 'Select Goal';
+
+  @override
+  String get manualEntryStudyTime => 'Study Time';
+
+  @override
+  String get manualEntryStudyDate => 'Study Date';
+
+  @override
+  String get manualEntryNoGoalSelected => 'Please select a goal';
+
+  @override
+  String get manualEntryNoTimeSelected => 'Please set a study time';
+
+  @override
+  String get manualEntrySaveSuccess => 'Study record saved!';
+
+  @override
+  String get manualEntrySaveFailed => 'Failed to save';
+
+  @override
+  String get manualEntryCongratsTitle => 'Great job!';
+
+  @override
+  String manualEntryCongratsMessage(String time) {
+    return 'Recorded $time of study';
+  }
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -670,4 +670,39 @@ class AppLocalizationsJa extends AppLocalizations {
   String repeatingNotificationMessage(String goal, String duration) {
     return '「$goal」の学習時間（$duration）を達成しました！お疲れ様です！';
   }
+
+  @override
+  String get manualEntryButton => '手動で記録する';
+
+  @override
+  String get manualEntryTitle => '手動で記録';
+
+  @override
+  String get manualEntrySelectGoal => '目標を選択';
+
+  @override
+  String get manualEntryStudyTime => '学習時間';
+
+  @override
+  String get manualEntryStudyDate => '学習日';
+
+  @override
+  String get manualEntryNoGoalSelected => '目標を選択してください';
+
+  @override
+  String get manualEntryNoTimeSelected => '学習時間を設定してください';
+
+  @override
+  String get manualEntrySaveSuccess => '学習記録を保存しました！';
+
+  @override
+  String get manualEntrySaveFailed => '保存に失敗しました';
+
+  @override
+  String get manualEntryCongratsTitle => 'お疲れ様でした！';
+
+  @override
+  String manualEntryCongratsMessage(String time) {
+    return '$timeの学習を記録しました';
+  }
 }

--- a/test/features/manual_entry/view_model/manual_entry_view_model_test.dart
+++ b/test/features/manual_entry/view_model/manual_entry_view_model_test.dart
@@ -1,0 +1,310 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:goal_timer/core/data/repositories/study_logs_repository.dart';
+import 'package:goal_timer/core/data/repositories/users_repository.dart';
+import 'package:goal_timer/core/models/goals/goals_model.dart';
+import 'package:goal_timer/core/models/study_daily_logs/study_daily_logs_model.dart';
+import 'package:goal_timer/core/services/auth_service.dart';
+import 'package:goal_timer/core/utils/streak_consts.dart';
+import 'package:goal_timer/features/manual_entry/view_model/manual_entry_view_model.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockStudyLogsRepository extends Mock implements StudyLogsRepository {}
+
+class MockUsersRepository extends Mock implements UsersRepository {}
+
+class MockAuthService extends Mock implements AuthService {}
+
+class FakeStudyDailyLogsModel extends Fake implements StudyDailyLogsModel {}
+
+void main() {
+  late MockStudyLogsRepository mockStudyLogsRepository;
+  late MockUsersRepository mockUsersRepository;
+  late MockAuthService mockAuthService;
+  late GoalsModel testGoal;
+
+  setUpAll(() {
+    registerFallbackValue(FakeStudyDailyLogsModel());
+  });
+
+  setUp(() {
+    mockStudyLogsRepository = MockStudyLogsRepository();
+    mockUsersRepository = MockUsersRepository();
+    mockAuthService = MockAuthService();
+    testGoal = GoalsModel(
+      id: 'test-goal-id',
+      userId: 'test-user-id',
+      title: 'Test Goal',
+      description: 'Test Description',
+      targetMinutes: 60,
+      avoidMessage: 'Test avoid message',
+      deadline: DateTime.now().add(const Duration(days: 30)),
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    );
+
+    when(() => mockAuthService.currentUserId).thenReturn('test-user-id');
+  });
+
+  ManualEntryViewModel createTestViewModel() {
+    return ManualEntryViewModel(
+      studyLogsRepository: mockStudyLogsRepository,
+      usersRepository: mockUsersRepository,
+      authService: mockAuthService,
+    );
+  }
+
+  tearDown(() {
+    Get.reset();
+  });
+
+  group('ManualEntryViewModel - 状態管理', () {
+    test('初期状態では目標が未選択であること', () {
+      final viewModel = createTestViewModel();
+      expect(viewModel.selectedGoal, isNull);
+      expect(viewModel.isGoalSelected, isFalse);
+    });
+
+    test('初期状態では学習時間がゼロであること', () {
+      final viewModel = createTestViewModel();
+      expect(viewModel.selectedDuration, Duration.zero);
+      expect(viewModel.isTimeSelected, isFalse);
+    });
+
+    test('初期状態では学習日が今日であること', () {
+      final viewModel = createTestViewModel();
+      final now = DateTime.now();
+      final today = DateTime(now.year, now.month, now.day);
+      expect(viewModel.selectedDate, today);
+    });
+
+    test('selectGoalで目標を設定できること', () {
+      final viewModel = createTestViewModel();
+      viewModel.selectGoal(testGoal);
+      expect(viewModel.selectedGoal, testGoal);
+      expect(viewModel.isGoalSelected, isTrue);
+    });
+
+    test('setDurationで学習時間を設定できること', () {
+      final viewModel = createTestViewModel();
+      viewModel.setDuration(const Duration(hours: 1, minutes: 30));
+      expect(viewModel.selectedDuration, const Duration(hours: 1, minutes: 30));
+      expect(viewModel.isTimeSelected, isTrue);
+    });
+
+    test('setDateで学習日を設定できること', () {
+      final viewModel = createTestViewModel();
+      final yesterday = DateTime.now().subtract(const Duration(days: 1));
+      viewModel.setDate(yesterday);
+      final expectedDate =
+          DateTime(yesterday.year, yesterday.month, yesterday.day);
+      expect(viewModel.selectedDate, expectedDate);
+    });
+  });
+
+  group('ManualEntryViewModel - バリデーション', () {
+    test('目標未選択の場合canSaveがfalseであること', () {
+      final viewModel = createTestViewModel();
+      viewModel.setDuration(const Duration(minutes: 30));
+      expect(viewModel.canSave, isFalse);
+    });
+
+    test('学習時間が0の場合canSaveがfalseであること', () {
+      final viewModel = createTestViewModel();
+      viewModel.selectGoal(testGoal);
+      expect(viewModel.canSave, isFalse);
+    });
+
+    test('目標と学習時間が設定されている場合canSaveがtrueであること', () {
+      final viewModel = createTestViewModel();
+      viewModel.selectGoal(testGoal);
+      viewModel.setDuration(const Duration(minutes: 30));
+      expect(viewModel.canSave, isTrue);
+    });
+
+    test('未来の日付は設定できないこと', () {
+      final viewModel = createTestViewModel();
+      final now = DateTime.now();
+      final today = DateTime(now.year, now.month, now.day);
+      final tomorrow = today.add(const Duration(days: 1));
+      viewModel.setDate(tomorrow);
+      expect(viewModel.selectedDate, today);
+    });
+  });
+
+  group('ManualEntryViewModel - 保存処理', () {
+    test('保存条件を満たさない場合saveがfalseを返すこと', () async {
+      final viewModel = createTestViewModel();
+      final result = await viewModel.save();
+      expect(result, isFalse);
+    });
+
+    test('正常に保存できた場合saveがtrueを返すこと', () async {
+      when(
+        () => mockStudyLogsRepository.upsertLog(any()),
+      ).thenAnswer((_) async => FakeStudyDailyLogsModel());
+
+      when(
+        () => mockStudyLogsRepository.calculateCurrentStreak(any()),
+      ).thenAnswer((_) async => 1);
+
+      when(
+        () => mockUsersRepository.updateLongestStreakIfNeeded(any(), any()),
+      ).thenAnswer((_) async => false);
+
+      final viewModel = createTestViewModel();
+      viewModel.selectGoal(testGoal);
+      viewModel.setDuration(const Duration(minutes: 30));
+
+      final result = await viewModel.save();
+
+      expect(result, isTrue);
+      verify(() => mockStudyLogsRepository.upsertLog(any())).called(1);
+    });
+
+    test('保存時にStudyDailyLogsModelが正しいパラメータで生成されること', () async {
+      StudyDailyLogsModel? capturedLog;
+
+      when(
+        () => mockStudyLogsRepository.upsertLog(any()),
+      ).thenAnswer((invocation) async {
+        capturedLog =
+            invocation.positionalArguments[0] as StudyDailyLogsModel;
+        return FakeStudyDailyLogsModel();
+      });
+
+      when(
+        () => mockStudyLogsRepository.calculateCurrentStreak(any()),
+      ).thenAnswer((_) async => 1);
+
+      when(
+        () => mockUsersRepository.updateLongestStreakIfNeeded(any(), any()),
+      ).thenAnswer((_) async => false);
+
+      final viewModel = createTestViewModel();
+      viewModel.selectGoal(testGoal);
+      viewModel.setDuration(const Duration(hours: 1, minutes: 30));
+      final yesterday = DateTime.now().subtract(const Duration(days: 1));
+      viewModel.setDate(yesterday);
+
+      await viewModel.save();
+
+      expect(capturedLog, isNotNull);
+      expect(capturedLog!.goalId, 'test-goal-id');
+      expect(capturedLog!.totalSeconds, 5400);
+      expect(capturedLog!.userId, 'test-user-id');
+      final expectedDate =
+          DateTime(yesterday.year, yesterday.month, yesterday.day);
+      expect(capturedLog!.studyDate, expectedDate);
+    });
+
+    test('1分以上の学習時間でストリーク更新が呼ばれること', () async {
+      when(
+        () => mockStudyLogsRepository.upsertLog(any()),
+      ).thenAnswer((_) async => FakeStudyDailyLogsModel());
+
+      when(
+        () => mockStudyLogsRepository.calculateCurrentStreak(any()),
+      ).thenAnswer((_) async => 5);
+
+      when(
+        () => mockUsersRepository.updateLongestStreakIfNeeded(any(), any()),
+      ).thenAnswer((_) async => true);
+
+      final viewModel = createTestViewModel();
+      viewModel.selectGoal(testGoal);
+      viewModel.setDuration(
+        Duration(seconds: StreakConsts.minStudySeconds),
+      );
+
+      await viewModel.save();
+
+      verify(
+        () => mockStudyLogsRepository.calculateCurrentStreak('test-user-id'),
+      ).called(1);
+      verify(
+        () =>
+            mockUsersRepository.updateLongestStreakIfNeeded(5, 'test-user-id'),
+      ).called(1);
+    });
+
+    test('1分未満の学習時間ではストリーク更新が呼ばれないこと', () async {
+      when(
+        () => mockStudyLogsRepository.upsertLog(any()),
+      ).thenAnswer((_) async => FakeStudyDailyLogsModel());
+
+      final viewModel = createTestViewModel();
+      viewModel.selectGoal(testGoal);
+      viewModel.setDuration(
+        Duration(seconds: StreakConsts.minStudySeconds - 1),
+      );
+
+      await viewModel.save();
+
+      verifyNever(
+        () => mockStudyLogsRepository.calculateCurrentStreak(any()),
+      );
+    });
+
+    test('保存中はisSavingがtrueになること', () async {
+      when(
+        () => mockStudyLogsRepository.upsertLog(any()),
+      ).thenAnswer((_) async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        return FakeStudyDailyLogsModel();
+      });
+
+      when(
+        () => mockStudyLogsRepository.calculateCurrentStreak(any()),
+      ).thenAnswer((_) async => 1);
+
+      when(
+        () => mockUsersRepository.updateLongestStreakIfNeeded(any(), any()),
+      ).thenAnswer((_) async => false);
+
+      final viewModel = createTestViewModel();
+      viewModel.selectGoal(testGoal);
+      viewModel.setDuration(const Duration(minutes: 30));
+
+      final future = viewModel.save();
+      expect(viewModel.isSaving, isTrue);
+      expect(viewModel.canSave, isFalse);
+
+      await future;
+      expect(viewModel.isSaving, isFalse);
+    });
+
+    test('保存失敗時にfalseを返しisSavingがfalseになること', () async {
+      when(
+        () => mockStudyLogsRepository.upsertLog(any()),
+      ).thenThrow(Exception('DB error'));
+
+      final viewModel = createTestViewModel();
+      viewModel.selectGoal(testGoal);
+      viewModel.setDuration(const Duration(minutes: 30));
+
+      final result = await viewModel.save();
+
+      expect(result, isFalse);
+      expect(viewModel.isSaving, isFalse);
+    });
+  });
+
+  group('ManualEntryViewModel - リセット', () {
+    test('resetで全ての状態がリセットされること', () {
+      final viewModel = createTestViewModel();
+      viewModel.selectGoal(testGoal);
+      viewModel.setDuration(const Duration(hours: 1));
+      viewModel.setDate(DateTime.now().subtract(const Duration(days: 3)));
+
+      viewModel.reset();
+
+      expect(viewModel.selectedGoal, isNull);
+      expect(viewModel.selectedDuration, Duration.zero);
+      expect(viewModel.isSaving, isFalse);
+      final now = DateTime.now();
+      final today = DateTime(now.year, now.month, now.day);
+      expect(viewModel.selectedDate, today);
+    });
+  });
+}


### PR DESCRIPTION
## 概要 / Overview
[学習時間の手動入力機能を追加](https://github.com/KakizakiHayate/goal-timer/issues/197)

Closes #197

## 実装内容 / Implementation details

### 新規ファイル
- **ManualEntryViewModel** (`lib/features/manual_entry/view_model/manual_entry_view_model.dart`)
  - 目標選択・学習時間設定・学習日選択の状態管理
  - バリデーション（目標未選択、時間0分、未来日付の防止）
  - StudyLogsRepository経由の保存処理
  - ストリーク更新処理（1分以上学習時のみ）

- **ManualEntryModal** (`lib/features/manual_entry/view/manual_entry_modal.dart`)
  - 95%高さのモーダル（既存のAddGoalModalと同じパターン）
  - 目標選択（カード形式の単一選択UI）
  - CupertinoTimerPicker（時間:分モード）
  - カレンダーUI（月ナビゲーション付き、未来日付は選択不可）
  - 保存時のバイブレーション＋達成演出ダイアログ

### 変更ファイル
- **home_screen.dart**
  - TimerタブのFABを既存の＋ボタンから「手動で記録する」カプセル型フローティングボタンに差し替え
  - HomeタブのFABは変更なし
  - スクロール中はフェードアウト、停止でフェードインするアニメーション
  - _TimerTabContentをStatefulWidgetに変更（スクロール検知のため）

- **l10nファイル**
  - app_ja.arb / app_en.arb に手動入力関連のキーを追加（12キー）

## 対応後のスクリーンショット / Screenshot after the fix
TBD

## テストケース / Test Case 

| No | シナリオ/Scenario | 環境/Environment | 手順/Steps | 期待結果/Expected Result |
|----|----------|------|------|----------|
| 1 | 初期状態の確認 | Unit Test | ViewModelを生成 | 目標未選択、時間0、学習日が今日 |
| 2 | 目標選択 | Unit Test | selectGoal()呼び出し | isGoalSelectedがtrue |
| 3 | 学習時間設定 | Unit Test | setDuration()呼び出し | isTimeSelectedがtrue |
| 4 | 学習日設定（過去） | Unit Test | setDate(昨日)呼び出し | 正しく設定される |
| 5 | 未来日付の拒否 | Unit Test | setDate(明日)呼び出し | 今日のまま変わらない |
| 6 | バリデーション（目標なし） | Unit Test | 時間のみ設定してcanSave確認 | false |
| 7 | バリデーション（時間なし） | Unit Test | 目標のみ設定してcanSave確認 | false |
| 8 | バリデーション（全て設定） | Unit Test | 目標+時間設定してcanSave確認 | true |
| 9 | 正常保存 | Unit Test | save()呼び出し | true、upsertLog()呼び出し確認 |
| 10 | 保存パラメータ確認 | Unit Test | save()でキャプチャ | goalId, totalSeconds, studyDate, userIdが正しい |
| 11 | ストリーク更新（1分以上） | Unit Test | 60秒でsave() | calculateCurrentStreak呼び出し確認 |
| 12 | ストリーク未更新（1分未満） | Unit Test | 59秒でsave() | calculateCurrentStreak未呼び出し |
| 13 | 保存中フラグ | Unit Test | save()実行中 | isSaving=true, canSave=false |
| 14 | 保存失敗 | Unit Test | upsertLogがthrow | false返却、isSaving=false |
| 15 | リセット | Unit Test | reset()呼び出し | 全状態が初期化 |

## チェックリスト / Check list
- [x] `flutter analyze` でリントエラーなし
- [x] `flutter test` で全380テスト通過（新規18テスト含む）
- [x] `flutter build ios --release --no-codesign` でビルド成功
- [ ] Assigneesを設定した
- [ ] Reviewersを設定した
- [ ] iOSとAndroidの実機で動作確認した
- [ ] iPhone SE3でもレイアウトが崩れていなかった
- [ ] Xperia Ace IIIでもレイアウトが崩れていなかった
- [x] Optional以外の項目を埋めた
- [ ] 積み残しがあった場合はチケット起票した

## 補足情報
- メモ欄は別タスクで対応予定
- 一括入力はCSVインポート等の別機能として将来検討
- 同じ目標・同じ日付に複数回記録した場合は、別レコードとして追加（既存のタイマー記録と同じ挙動）


🤖 Generated with [Claude Code](https://claude.com/claude-code)