### PR TITLE
fix(notification/timer): Future.wait()の未処理例外にtry-catchを追加 #199

### DIFF
--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -184,7 +184,15 @@ class NotificationService {
       ids.add(notificationId);
     }
 
-    await Future.wait(futures);
+    try {
+      await Future.wait(futures);
+    } catch (error, stackTrace) {
+      AppLogger.instance.e(
+        'NotificationService: 繰り返し通知のスケジュールに失敗しました',
+        error,
+        stackTrace,
+      );
+    }
     _scheduledRepeatingNotificationIds = ids;
 
     AppLogger.instance.i(
@@ -203,7 +211,15 @@ class NotificationService {
     _scheduledRepeatingNotificationIds = [];
 
     if (idsToCancel.isNotEmpty) {
-      await Future.wait(idsToCancel.map((id) => _notifications.cancel(id)));
+      try {
+        await Future.wait(idsToCancel.map((id) => _notifications.cancel(id)));
+      } catch (error, stackTrace) {
+        AppLogger.instance.e(
+          'NotificationService: 繰り返し通知のキャンセルに失敗しました',
+          error,
+          stackTrace,
+        );
+      }
 
       AppLogger.instance.i(
         'NotificationService: 繰り返し通知を${idsToCancel.length}個キャンセルしました',

--- a/lib/features/timer/view_model/timer_view_model.dart
+++ b/lib/features/timer/view_model/timer_view_model.dart
@@ -209,9 +209,17 @@ class TimerViewModel extends GetxController {
   @override
   void onClose() {
     _timer?.cancel();
-    _audioService.dispose();
+    try {
+      _audioService.dispose();
+    } catch (error, stackTrace) {
+      AppLogger.instance.e('AudioServiceのdisposeに失敗しました', error, stackTrace);
+    }
     // タイマー完了通知のみキャンセル（ストリークリマインダーは維持）
-    _notificationService.cancelScheduledNotification();
+    try {
+      _notificationService.cancelScheduledNotification();
+    } catch (error, stackTrace) {
+      AppLogger.instance.e('通知のキャンセルに失敗しました', error, stackTrace);
+    }
     super.onClose();
   }
 
@@ -397,11 +405,19 @@ class TimerViewModel extends GetxController {
   /// 完了通知をスケジュールする（繰り返し通知）
   Future<void> _scheduleCompletionNotification() async {
     if (state.currentSeconds > TimeUtils.minValidSeconds) {
-      await _notificationService.scheduleRepeatingCompletionNotifications(
-        delayBeforeCompletionSeconds: state.currentSeconds,
-        goalTitle: goal.title,
-        studyDurationSeconds: state.totalSeconds,
-      );
+      try {
+        await _notificationService.scheduleRepeatingCompletionNotifications(
+          delayBeforeCompletionSeconds: state.currentSeconds,
+          goalTitle: goal.title,
+          studyDurationSeconds: state.totalSeconds,
+        );
+      } catch (error, stackTrace) {
+        AppLogger.instance.e(
+          '完了通知のスケジュールに失敗しました',
+          error,
+          stackTrace,
+        );
+      }
     }
   }
 
@@ -429,7 +445,15 @@ class TimerViewModel extends GetxController {
         // バックグラウンド中に完了した場合
         _elapsedSeconds = state.totalSeconds;
         // 残りの繰り返し通知をキャンセル（ユーザーがアプリに戻ったため不要）
-        _notificationService.cancelRepeatingCompletionNotifications();
+        try {
+          _notificationService.cancelRepeatingCompletionNotifications();
+        } catch (error, stackTrace) {
+          AppLogger.instance.e(
+            '繰り返し通知のキャンセルに失敗しました',
+            error,
+            stackTrace,
+          );
+        }
         completeTimer();
         AppLogger.instance.i('バックグラウンド中にタイマーが完了しました');
       } else {

--- a/test/features/timer/view_model/timer_view_model_test.dart
+++ b/test/features/timer/view_model/timer_view_model_test.dart
@@ -812,6 +812,109 @@ void main() {
         ).called(1);
       });
     });
+
+    group('例外ハンドリング（T-7.x）', () {
+      test(
+          'T-7.1: _scheduleCompletionNotificationで例外が発生してもタイマーが正常に動作すること',
+          () {
+        // Arrange: 通知スケジュールが例外をスロー
+        when(
+          () => mockNotificationService
+              .scheduleRepeatingCompletionNotifications(
+            delayBeforeCompletionSeconds:
+                any(named: 'delayBeforeCompletionSeconds'),
+            goalTitle: any(named: 'goalTitle'),
+            studyDurationSeconds: any(named: 'studyDurationSeconds'),
+          ),
+        ).thenThrow(Exception('通知スケジュールエラー'));
+
+        final viewModel = createTestViewModel();
+
+        // Act: startTimerが例外をスローせず正常に完了すること
+        viewModel.startTimer();
+
+        // Assert: タイマーはrunning状態
+        expect(viewModel.state.status, equals(TimerStatus.running));
+
+        viewModel.onClose();
+      });
+
+      test(
+          'T-7.2: onAppResumedでcancelRepeatingCompletionNotificationsが例外をスローしても復帰処理が完了すること',
+          () {
+        // Arrange
+        when(
+          () =>
+              mockNotificationService.cancelRepeatingCompletionNotifications(),
+        ).thenThrow(Exception('キャンセルエラー'));
+
+        fakeSettingsViewModel.defaultTimerSeconds.value = 0;
+        final viewModel = createTestViewModel();
+
+        // Act: 開始→バックグラウンド→復帰（完了判定）
+        viewModel.startTimer();
+        viewModel.onAppPaused();
+        viewModel.onAppResumed();
+
+        // Assert: タイマーが完了状態になっていること（例外で中断されない）
+        expect(viewModel.state.status, equals(TimerStatus.completed));
+
+        viewModel.onClose();
+      });
+
+      test(
+          'T-7.3: onCloseでaudioService.dispose()が例外をスローしてもcancelScheduledNotificationが呼ばれること',
+          () {
+        // Arrange
+        when(() => mockAudioService.dispose()).thenThrow(
+          Exception('dispose エラー'),
+        );
+
+        final viewModel = createTestViewModel();
+        viewModel.startTimer();
+
+        // Act
+        viewModel.onClose();
+
+        // Assert: dispose例外後もcancelScheduledNotificationが呼ばれること
+        verify(
+          () => mockNotificationService.cancelScheduledNotification(),
+        ).called(1);
+      });
+
+      test(
+          'T-7.4: onCloseでcancelScheduledNotificationが例外をスローしてもonCloseが正常に完了すること',
+          () {
+        // Arrange
+        when(
+          () => mockNotificationService.cancelScheduledNotification(),
+        ).thenThrow(Exception('キャンセルエラー'));
+
+        final viewModel = createTestViewModel();
+        viewModel.startTimer();
+
+        // Act & Assert: 例外がスローされないこと
+        expect(() => viewModel.onClose(), returnsNormally);
+      });
+
+      test(
+          'T-7.5: onCloseでaudioServiceとnotificationServiceの両方が例外をスローしてもonCloseが正常に完了すること',
+          () {
+        // Arrange
+        when(() => mockAudioService.dispose()).thenThrow(
+          Exception('dispose エラー'),
+        );
+        when(
+          () => mockNotificationService.cancelScheduledNotification(),
+        ).thenThrow(Exception('キャンセルエラー'));
+
+        final viewModel = createTestViewModel();
+        viewModel.startTimer();
+
+        // Act & Assert: 例外がスローされないこと
+        expect(() => viewModel.onClose(), returnsNormally);
+      });
+    });
   });
 
   group('タイマー完了時の音声再生テスト', () {


### PR DESCRIPTION
## 概要 / Overview
[NotificationService の Future.wait() 未処理例外による app_exception 発生（v1.0.5）](https://github.com/KakizakiHayate/goal-timer/issues/199)

Closes #199

## 実装内容 / Implementation details

### 原因
v1.0.5で追加された繰り返し通知機能の`Future.wait()`にtry-catchがなく、GA4で`app_exception`が26回発生していた。

### 対応（5箇所にtry-catchを追加）

| # | ファイル | メソッド | 対応内容 |
|---|---------|---------|---------|
| 1 | `notification_service.dart` | `scheduleRepeatingCompletionNotifications()` | `Future.wait(futures)`をtry-catchで囲む |
| 2 | `notification_service.dart` | `cancelRepeatingCompletionNotifications()` | `Future.wait(...)`をtry-catchで囲む |
| 3 | `timer_view_model.dart` | `_scheduleCompletionNotification()` | 通知サービス呼び出しをtry-catchで囲む |
| 4 | `timer_view_model.dart` | `onAppResumed()` | キャンセル呼び出しをtry-catchで囲む |
| 5 | `timer_view_model.dart` | `onClose()` | 各cleanup処理を個別にtry-catchで囲む |

## 対応後のスクリーンショット / Screenshot after the fix
UIの変更なし（エラーハンドリングのみの修正）

## テストケース / Test Case

| No | シナリオ/Scenario | 環境/Environment | 手順/Steps | 期待結果/Expected Result |
|----|----------|------|------|----------|
| T-7.1 | 通知スケジュール例外時のタイマー動作 | Unit Test | scheduleRepeatingCompletionNotificationsが例外をスロー→startTimer() | タイマーがrunning状態で正常動作 |
| T-7.2 | バックグラウンド復帰時のキャンセル例外 | Unit Test | cancelRepeatingCompletionNotificationsが例外をスロー→onAppResumed() | タイマーがcompleted状態に遷移 |
| T-7.3 | onCloseでdispose例外時の通知キャンセル | Unit Test | audioService.dispose()が例外→onClose() | cancelScheduledNotificationが呼ばれる |
| T-7.4 | onCloseでキャンセル例外時の完了 | Unit Test | cancelScheduledNotificationが例外→onClose() | 例外がスローされず正常完了 |
| T-7.5 | onCloseで両方例外時の完了 | Unit Test | dispose+cancelの両方が例外→onClose() | 例外がスローされず正常完了 |

## チェックリスト / Check list
- [x] `flutter analyze` でLintエラーなし
- [x] `flutter test` で全367テスト通過
- [x] `flutter build ios --release --no-codesign` でビルド成功
- [x] 既存テストに影響なし（正常系の動作変更なし）
- [x] 新規テスト5件追加・通過

## 補足情報
- 正常系の動作に変更はなく、try-catchの追加のみ
- エラー発生時はAppLoggerでstackTrace付きのログを出力