### PR TITLE
chore: アプリバージョンを1.1.1+15に変更

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: goal_timer
 description: "A new Flutter project."
 publish_to: 'none'
 
-version: 1.1.0+14
+version: 1.1.1+15
 
 environment:
   sdk: '>=3.7.0 <4.0.0'


### PR DESCRIPTION
## Summary
- アプリバージョンを `1.1.0+14` → `1.1.1+15` に変更

## Test plan
- [x] バージョン番号の変更のみ、動作への影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)